### PR TITLE
feat(cli): compatible with angular cli using 'ng install'

### DIFF
--- a/ng2-translate.ts
+++ b/ng2-translate.ts
@@ -1,3 +1,11 @@
+import {TranslatePipe} from './src/translate.pipe';
+import {TranslateService} from './src/translate.service';
+
 export * from './src/translate.pipe';
 export * from './src/translate.service';
 export * from './src/translate.parser';
+
+export default {
+  pipes: [TranslatePipe],
+  providers: [TranslateService]
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "angular2": "~2.0.0-beta.0",
     "es6-promise": "~3.0.2",
     "es6-shim": "~0.33.3",
-    "reflect-metadata": "~0.1.2",
-    "rxjs": "~5.0.0-beta.0",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-beta.0",
     "zone.js": "~0.5.10"
   },
   "devDependencies": {
@@ -50,8 +50,8 @@
     "angular2": "~2.0.0-beta.0",
     "es6-promise": "~3.0.2",
     "es6-shim": "~0.33.3",
-    "reflect-metadata": "~0.1.2",
-    "rxjs": "~5.0.0-beta.0",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-beta.0",
     "zone.js": "~0.5.10"
   },
   "czConfig": {

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -1,9 +1,9 @@
 import {Injectable, EventEmitter} from 'angular2/core';
 import {Http, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable'
-import 'rxjs/add/observable/fromArray.js';
-import 'rxjs/add/operator/share.js';
-import 'rxjs/add/operator/map.js';
+import 'rxjs/add/observable/fromArray';
+import 'rxjs/add/operator/share';
+import 'rxjs/add/operator/map';
 
 import {Parser} from './translate.parser';
 


### PR DESCRIPTION
With this, users will be able to use the latest `angular cli`, which now has a new option:
`ng install ng2-translate` to auto-annotate their source if they choose, or custom install the lib.
https://github.com/angular/angular-cli/commit/019514681d990a54acfa6e1f46f7b6001a7674a8

@jkuri If you could also help @ocombe with the ability to target builds for `systemjs` and `webpack` in regards to how your implementation for `angular cli` expects would be great.