### PR TITLE
feat(cli): compatible with angular cli using 'ng install'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ coverage
 !karma-test-shim.js
 *.map
 *.d.ts
+!make.js
+
+#################
+## Bundles
+#################
+bundles/
 
 #################
 ## JetBrains

--- a/make.js
+++ b/make.js
@@ -1,0 +1,36 @@
+var pkg     = require('./package.json');
+var path    = require('path');
+var Builder = require('systemjs-builder');
+var name    = pkg.name;
+
+var builder = new Builder();
+var config = {
+  baseURL: '.',
+  transpiler: 'typescript',
+  typescriptOptions: {
+    module: 'cjs'
+  },
+  map: {
+    typescript: './node_modules/typescript/lib/typescript.js',
+    angular2: path.resolve('node_modules/angular2'),
+    rxjs: path.resolve('node_modules/rxjs')
+  },
+  paths: {
+    '*': '*.js'
+  },
+  meta: {
+    'node_modules/angular2/*': { build: false },
+    'node_modules/rxjs/*': { build: false }
+  },
+};
+
+builder.config(config);
+
+builder
+.bundle(name, path.resolve(__dirname, 'bundles/', name + '.js'))
+.then(function() {
+  console.log('Build complete.');
+})
+.catch(function(err) {
+  console.log('Error', err);
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "tsc && karma start",
     "test-watch": "tsc && karma start --no-single-run --auto-watch",
     "commit": "git-cz",
-    "prepublish": "tsc",
+    "prepublish": "tsc && node make.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -35,23 +35,23 @@
     "zone.js": "~0.5.10"
   },
   "devDependencies": {
+    "angular2": "~2.0.0-beta.0",
     "commitizen": "~2.4.6",
     "cz-conventional-changelog": "~1.1.4",
+    "es6-promise": "~3.0.2",
+    "es6-shim": "~0.33.3",
     "jasmine-core": "~2.3.4",
     "karma": "~0.13.15",
     "karma-chrome-launcher": "~0.2.2",
     "karma-firefox-launcher": "~0.1.7",
     "karma-jasmine": "~0.3.6",
     "karma-typescript-preprocessor": "0.0.21",
-    "semantic-release": "~4.3.5",
-    "systemjs": "~0.19.6",
-    "typescript": "~1.7.3",
-
-    "angular2": "~2.0.0-beta.0",
-    "es6-promise": "~3.0.2",
-    "es6-shim": "~0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
+    "semantic-release": "~4.3.5",
+    "systemjs": "~0.19.6",
+    "systemjs-builder": "^0.15.6",
+    "typescript": "~1.7.3",
     "zone.js": "~0.5.10"
   },
   "czConfig": {


### PR DESCRIPTION
Hi @ocombe. I added bundler script to make it compatible with angular-clis `ng install ng2-translate` command. If you can merge this and publish to npm I think we can use this library as a real-world example as it also provides one provider in the [documentation](https://github.com/angular/angular-cli/pull/173) instead of a test library.