### PR TITLE
fix#53 fixed the subkey issue.

### DIFF
--- a/src/translate.parser.ts
+++ b/src/translate.parser.ts
@@ -32,7 +32,7 @@ export class Parser {
         key = '';
         do {
             key += keys.shift();
-            if (target[key]) {
+            if (target[key] && (typeof target[key] === 'object' || !keys.length)) {
                 target = target[key];
                 key = '';
             } else if (!keys.length) {

--- a/tests/translate.parser.spec.ts
+++ b/tests/translate.parser.spec.ts
@@ -33,6 +33,10 @@ export function main() {
             expect(parser.getValue({key1: {'key2.key3': "value3"}}, 'key1.key2.key3')).toEqual("value3");
             expect(parser.getValue({'key1.key2.key3': "value3"}, 'key1.key2.key3')).toEqual("value3");
             expect(parser.getValue({'key1.key2': {key3: "value3"}}, 'key1.key2.keyWrong')).not.toBeDefined();
+            expect(parser.getValue({
+                'key1': "value1",
+                'key1.key2' : "value2"
+            }, 'key1.key2')).toEqual("value2");
 
         });
     });


### PR DESCRIPTION
As i mentioned in #56 there is a problem with subkeys in strings:

```
'key' : 'value',
'key.subkey' : 'another value'
```

So here is the fix that does not harm all the other cases. 