### PR TITLE
fix(pipe) - more robust when keys are falsy

### DIFF
--- a/src/translate.pipe.ts
+++ b/src/translate.pipe.ts
@@ -76,7 +76,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     }
 
     transform(query: string, args: any[]): any {
-        if(query.length === 0) {
+        if(!query || query.length === 0) {
             return query;
         }
         // if we ask another time for the same key, return the last value


### PR DESCRIPTION
Translate pipe should not generate an error when receiving a falsy value such as undefined.
