### PR TITLE
Remove fromArray import

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -2,7 +2,6 @@ import {Injectable, EventEmitter, Optional} from 'angular2/core';
 import {Http, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable'
 import {Observer} from "rxjs/Observer";
-import 'rxjs/add/observable/fromArray';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/merge';

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -2,6 +2,7 @@ import {Injectable, EventEmitter, Optional} from 'angular2/core';
 import {Http, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable'
 import {Observer} from "rxjs/Observer";
+import 'rxjs/add/operator/of';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/merge';


### PR DESCRIPTION
`Observable.fromArray` does not exist in the latest beta of RxJS 5. It is deprecated in favour of `Observable.from`.
I've simply removed the import as it's not used in this file anyway.