### PR TITLE
update RxJS version to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angular2": ">= 2.0.0-beta.10",
     "es6-shim": ">= 0.33.3",
     "reflect-metadata": ">= 0.1.2",
-    "rxjs": ">= 5.0.0-beta.2",
+    "rxjs": ">= 5.0.0-beta.4",
     "zone.js": ">= 0.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The RxJS 5 beta 2 bundle doesn't contain 'add/observable/of', which throws an error.
Beta 2 https://github.com/ReactiveX/rxjs/blob/9c887a49eda1a5ae87ae25b0f6eb49a9a63bf6f2/src/Rx.ts
Beta 4 https://github.com/ReactiveX/rxjs/blob/c4f6a5f8fc19fb2e340f0a4664dd91669923a400/src/Rx.ts