### PR TITLE
remove obersvable.of import

### DIFF
--- a/bundles/ng2-translate.js
+++ b/bundles/ng2-translate.js
@@ -128,7 +128,7 @@ System.registerDynamic("src/translate.pipe", ["angular2/core", "./translate.serv
   return module.exports;
 });
 
-System.registerDynamic("src/translate.service", ["angular2/core", "angular2/http", "rxjs/Observable", "rxjs/add/observable/of", "rxjs/add/operator/share", "rxjs/add/operator/map", "rxjs/add/operator/merge", "rxjs/add/operator/toArray", "./translate.parser"], true, function($__require, exports, module) {
+System.registerDynamic("src/translate.service", ["angular2/core", "angular2/http", "rxjs/Observable", "rxjs/add/operator/share", "rxjs/add/operator/map", "rxjs/add/operator/merge", "rxjs/add/operator/toArray", "./translate.parser"], true, function($__require, exports, module) {
   "use strict";
   ;
   var define,
@@ -158,7 +158,6 @@ System.registerDynamic("src/translate.service", ["angular2/core", "angular2/http
   var core_1 = $__require('angular2/core');
   var http_1 = $__require('angular2/http');
   var Observable_1 = $__require('rxjs/Observable');
-  $__require('rxjs/add/observable/of');
   $__require('rxjs/add/operator/share');
   $__require('rxjs/add/operator/map');
   $__require('rxjs/add/operator/merge');

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -2,7 +2,6 @@ import {Injectable, EventEmitter, Optional} from 'angular2/core';
 import {Http, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable'
 import {Observer} from "rxjs/Observer";
-import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/merge';


### PR DESCRIPTION
In rxjs5beta2, Obervable.of is a static method in the Observable class, and therefore although the /observable/of does exists, it is not used nor packaged. This new file (of.ts) is used correctly in rxjs5beta3.

While I realize changing the bundle file was obsolete, it was easier to test that way.