### PR TITLE
[Issue#87] fix target undefined for missing translation

### DIFF
--- a/src/translate.parser.ts
+++ b/src/translate.parser.ts
@@ -32,7 +32,7 @@ export class Parser {
         key = '';
         do {
             key += keys.shift();
-            if (target[key] !== undefined && (typeof target[key] === 'object' || !keys.length)) {
+            if (target!==undefined && target[key] !== undefined && (typeof target[key] === 'object' || !keys.length)) {
                 target = target[key];
                 key = '';
             } else if (!keys.length) {


### PR DESCRIPTION
when the keys are shifted, somewhen the target gets set to undefined (L39). the loop terminates only after the next interation. in the meanwhile an exception is thrown and the further translation is aborted -> therefore added a check for undefined to exit the loop correctly without exception