### PR TITLE
fix(TranslatePipe): update translations after translateService.set called

### DIFF
--- a/bundles/ng2-translate.js
+++ b/bundles/ng2-translate.js
@@ -109,6 +109,14 @@ System.registerDynamic("src/translate.pipe", ["@angular/core", "./translate.serv
       this.lastParams = args;
       this.updateValue(query, interpolateParams);
       this._dispose();
+      if (!this.onTranslationChange) {
+        this.onTranslationChange = this.translate.onTranslationChange.subscribe(function(event) {
+          if (_this.lastKey) {
+            _this.lastKey = null;
+            _this.updateValue(query, interpolateParams);
+          }
+        });
+      }
       if (!this.onLangChange) {
         this.onLangChange = this.translate.onLangChange.subscribe(function(event) {
           _this.lastKey = null;
@@ -118,6 +126,10 @@ System.registerDynamic("src/translate.pipe", ["@angular/core", "./translate.serv
       return this.value;
     };
     TranslatePipe.prototype._dispose = function() {
+      if (lang_1.isPresent(this.onTranslationChange)) {
+        this.onTranslationChange.unsubscribe();
+        this.onTranslationChange = undefined;
+      }
       if (lang_1.isPresent(this.onLangChange)) {
         this.onLangChange.unsubscribe();
         this.onLangChange = undefined;
@@ -206,6 +218,7 @@ System.registerDynamic("src/translate.service", ["@angular/core", "rxjs/Observab
       this.currentLoader = currentLoader;
       this.missingTranslationHandler = missingTranslationHandler;
       this.currentLang = this.defaultLang;
+      this.onTranslationChange = new core_1.EventEmitter();
       this.onLangChange = new core_1.EventEmitter();
       this.translations = {};
       this.parser = new translate_parser_1.Parser();
@@ -351,6 +364,11 @@ System.registerDynamic("src/translate.service", ["@angular/core", "rxjs/Observab
       }
       this.translations[lang][key] = value;
       this.updateLangs();
+      this.onTranslationChange.emit({
+        key: key,
+        value: value,
+        lang: lang
+      });
     };
     TranslateService.prototype.changeLang = function(lang) {
       this.currentLang = lang;

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -10,6 +10,12 @@ import 'rxjs/add/operator/toArray';
 
 import {Parser} from './translate.parser';
 
+export interface TranslationChangedEvent {
+    key: string;
+    value: string;
+    lang: string;
+}
+
 export interface LangChangeEvent {
     lang: string;
     translations: any;
@@ -51,6 +57,15 @@ export class TranslateService {
      * The lang currently used
      */
     public currentLang: string = this.defaultLang;
+
+    /**
+     * An EventEmitter to listen to key's translation changed
+     * onTranslationChange.subscribe((params: TranslationChangedEvent) => {
+     *     // do something
+     * });
+     * @type {ng.EventEmitter<TranslationChangedEvent>}
+     */
+    public onTranslationChange: EventEmitter<TranslationChangedEvent> = new EventEmitter<TranslationChangedEvent>();
 
     /**
      * An EventEmitter to listen to lang changes events
@@ -280,6 +295,7 @@ export class TranslateService {
     public set(key: string, value: string, lang: string = this.currentLang): void {
         this.translations[lang][key] = value;
         this.updateLangs();
+        this.onTranslationChange.emit({key:key, value: value, lang: lang});
     }
 
     /**

--- a/tests/translate.pipe.spec.ts
+++ b/tests/translate.pipe.spec.ts
@@ -3,7 +3,7 @@ import {MockConnection, MockBackend} from "@angular/http/testing/mock_backend";
 import {TRANSLATE_PROVIDERS, TranslateService} from "./../ng2-translate";
 import {ResponseOptions, Response, XHRBackend, HTTP_PROVIDERS} from "@angular/http";
 import {provide, Injector, ReflectiveInjector, ChangeDetectorRef} from "@angular/core";
-import {LangChangeEvent} from "../src/translate.service";
+import {LangChangeEvent, TranslationChangedEvent} from "../src/translate.service";
 
 class FakeChangeDetectorRef extends ChangeDetectorRef {
     markForCheck(): void {}
@@ -116,6 +116,26 @@ export function main() {
             expect(() => {
                 translatePipe.transform('TEST', param);
             }).toThrowError(`Wrong parameter in TranslatePipe. Expected a valid Object, received: ${param}`)
+        });
+
+        describe('should update translations on translation by key change', () => {
+            it('with static loader', (done) => {
+                translate.setTranslation('en', {"TEST": "This is a test"});
+                translate.use('en');
+
+                expect(translatePipe.transform('TEST')).toEqual("This is a test");
+
+                // this will be resolved at the next key's translation change
+                let subscription = translate.onTranslationChange.subscribe(
+                    (res: TranslationChangedEvent) => {
+                        expect(res.key).toEqual('TEST');
+                        expect(translatePipe.transform('TEST')).toEqual("This is new test value");
+                        subscription.unsubscribe();
+                        done();
+                    });
+
+                translate.set('TEST', 'This is new test value', 'en');
+            });
         });
 
         describe('should update translations on lang change', () => {

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -8,7 +8,8 @@ import {
     MissingTranslationHandler,
     TranslateLoader,
     TranslateStaticLoader,
-    LangChangeEvent
+    LangChangeEvent,
+    TranslationChangedEvent
 } from './../ng2-translate';
 import {Observable} from "rxjs/Observable";
 
@@ -181,6 +182,16 @@ export function main() {
             translate.use('en');
 
             expect(translate.instant('TEST2')).toEqual('TEST2');
+        });
+
+        it('should trigger an event when the translation value changes', () => {
+            translate.setTranslation('en', {});
+            translate.onTranslationChange.subscribe((event: TranslationChangedEvent) => {
+                expect(event.key).toEqual("TEST");
+                expect(event.value).toEqual("This is a test");
+                expect(event.lang).toBe('en');
+            });
+            translate.set("TEST", "This is a test", 'en');
         });
 
         it('should trigger an event when the lang changes', () => {


### PR DESCRIPTION
It would be great automatically update translation when `translateService.set` was called