### PR TITLE
Getter and setter for array of available languages.

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -65,6 +65,7 @@ export class TranslateService {
     private translations: any = {};
     private defaultLang: string;
     private langs: Array<string>;
+    private availableLangs: Array<string>;
     private parser: Parser = new Parser();
 
     /**
@@ -144,6 +145,22 @@ export class TranslateService {
      */
     public getLangs(): Array<string> {
         return this.langs;
+    }
+
+    /**
+     * Returns an array of available langs
+     * @returns {Array<string>}
+     */
+    public getAvailableLangs(): Array<string> {
+        return this.availableLangs;
+    }
+
+    /**
+     * @param langs
+     * Set available langs
+     */
+    public setAvailableLangs(langs: Array<string>): void {
+        this.availableLangs = langs;
     }
 
     /**

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -239,6 +239,12 @@ export function main() {
             // mock response after the xhr request, otherwise it will be undefined
             mockBackendResponse(connection, '{"TEST": "This is a test"}');
         });
+
+        it('should be able to set and get array of available languages', () => {
+            translate.setAvailableLangs(['en', 'pl']);
+
+            expect(translate.getAvailableLangs()).toEqual(['en', 'pl']);
+        });
     });
 
     describe('MissingTranslationHandler', () => {


### PR DESCRIPTION
Getter and setter methods for provide array of available languages.

For example:
On translate library init i can declare languages available in system by call:
`translate.setAvailableLangs(['en', 'pl', 'de']);`
And next i can render menu by get available (but not necessary currently loaded) languages:
`this.availableLangs = translate.getAvailableLangs();`