### PR TITLE
Add typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/ocombe/ng2-translate/issues"
   },
   "main": "ng2-translate.js",
+  "typings": "./ng2-translate.d.ts",
   "homepage": "https://github.com/ocombe/ng2-translate",
   "peerDependencies": {
     "@angular/core": "^2.0.0-rc.5",


### PR DESCRIPTION
"typings" key is required in package.json so that tsc knows where to find the typings for this module