### PR TITLE
Fixing which language to use

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -355,7 +355,7 @@ export class TranslateService {
         }
         let browserLang: any;
         if (typeof window.navigator['languages'] !== 'undefined' && window.navigator['languages'].length > 0) {
-            browserLang = window.navigator['languages'][0].indexOf('-') !== -1 || window.navigator['languages'].length < 2 ? window.navigator['languages'][0] : window.navigator['languages'][1];
+            browserLang = window.navigator['languages'][0];
         } else {
             browserLang = window.navigator['language'] || window.navigator['browserLanguage'];
         }


### PR DESCRIPTION
Thank you so much for adding the the `TranslateService.getBrowserLang()` .. this is awesome. I just wanted to update how you are determining which language to use when there are more than 1 set in the browser. 

If the browsers languages have more than one language, just grab the users number one preference. For instance, if I am a spanish user in the US and my device language is in spanish, `window.navigator.language` shows 'es' and my `window.navigator.languages = ['es', 'en-US', 'en']` .. just grab `'es'`