### PR TITLE
fix(TranslateModule): use exported factory function to enable AOT compiling

### DIFF
--- a/ng2-translate.ts
+++ b/ng2-translate.ts
@@ -13,6 +13,10 @@ export default {
     providers: [TranslateService]
 };
 
+export function translateLoaderFactory(http: Http) {
+    return new TranslateStaticLoader(http);
+}
+
 @NgModule({
     imports: [HttpModule],
     declarations: [
@@ -26,7 +30,7 @@ export default {
 export class TranslateModule {
     static forRoot(providedLoader: any = {
         provide: TranslateLoader,
-        useFactory: (http: Http) => new TranslateStaticLoader(http),
+        useFactory: translateLoaderFactory,
         deps: [Http]
     }): ModuleWithProviders {
         return {


### PR DESCRIPTION
I haven't tested it with this module but in other cases this change fixed the problem.

Should close https://github.com/ocombe/ng2-translate/issues/218