### PR TITLE
chore(refactor): use ngc to compile for distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,25 +82,6 @@ export class SharedModule {
 }
 ```
 
-##### _Ionic 2 users:_
-
-For Ionic 2 here is a complete bootstrap with configuration. Ionic 2 still uses Angular 2 RC4, which means that you should use ng2-translate version 2.2.2:
-```ts
-import {TranslateService, TranslateLoader, TranslateStaticLoader} from 'ng2-translate/ng2-translate';
-
-@Component({
-  templateUrl: '....',
-  providers: [
-    { 
-      provide: TranslateLoader,
-      useFactory: (http: Http) => new TranslateStaticLoader(http, 'assets/i18n', '.json'),
-      deps: [Http]
-    },
-    TranslateService
-  ]
-})
-```
-
 #### 2. Init the `TranslateService` for your application:
 
 ```ts

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -70,7 +70,10 @@ module.exports = {
                 exclude: [
                     /\.(e2e|spec)\.ts$/,
                     /node_modules/
-                ]
+                ],
+                query: {
+                  esModules: true
+                }
             }
         ]
     },

--- a/make.js
+++ b/make.js
@@ -27,7 +27,7 @@ var config = {
 builder.config(config);
 
 builder
-.bundle(name, path.resolve(__dirname, 'bundles/', name + '.js'))
+.buildStatic(name, path.resolve(__dirname, 'bundles/', name + '.js'), {format: 'umd'})
 .then(function() {
   console.log('Build complete.');
 })

--- a/ng2-translate.ts
+++ b/ng2-translate.ts
@@ -7,12 +7,6 @@ export * from "./src/translate.pipe";
 export * from "./src/translate.service";
 export * from "./src/translate.parser";
 
-// for angular-cli
-export default {
-    pipes: [TranslatePipe],
-    providers: [TranslateService]
-};
-
 export function translateLoaderFactory(http: Http) {
     return new TranslateStaticLoader(http);
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "bugs": {
     "url": "https://github.com/ocombe/ng2-translate/issues"
   },
-  "main": "ng2-translate.js",
+  "main": "bundles/ng2-translate.js",
+  "module": "ng2-translate.js",
   "typings": "./ng2-translate.d.ts",
   "homepage": "https://github.com/ocombe/ng2-translate",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "tsc && karma start",
     "test-watch": "tsc && concurrently \"tsc -w\" \"karma start karma.conf.js\"",
     "commit": "npm run prepublish && npm test && git-cz",
-    "prepublish": "tsc && node make.js",
+    "prepublish": "ngc && node make.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@angular/common": "2.0.0",
     "@angular/compiler": "2.0.0",
+    "@angular/compiler-cli": "^0.6.3",
     "@angular/core": "2.0.0",
     "@angular/http": "2.0.0",
     "@angular/platform-browser": "2.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
-    "module": "commonjs",
+    "module": "es2015",
     "target": "es5",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,9 @@
   "exclude": [
     "node_modules",
     "bundles"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
 }


### PR DESCRIPTION
- uses `ngc` to generate the distribution files, making this compatible with AoT compilation. 
- distributes ES modules + UMD bundle, making this compatible with rollup/webpack2/treeshaking.

closes #218 
closes #248 