### PR TITLE
Update translate.service.ts

### DIFF
--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -104,6 +104,10 @@ export class TranslateService {
         this.defaultLang = lang;
     }
 
+    public getDefaultLang(): string {
+        return this.defaultLang;   
+    }
+
     /**
      * Changes the lang currently used
      * @param lang

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -104,6 +104,10 @@ export class TranslateService {
         this.defaultLang = lang;
     }
 
+    /**
+     * Gets the default language used
+     * @returns string
+     */
     public getDefaultLang(): string {
         return this.defaultLang;   
     }


### PR DESCRIPTION
Allows to avoid this case (used in the [plunker](http://plnkr.co/edit/btpW3l0jr5beJVjohy1Q?p=preview)):

```
translate.addLangs(["en", "fr"]);
translate.setDefaultLang('en');

let browserLang = translate.getBrowserLang();
translate.use(browserLang.match(/en|fr/) ? browserLang : 'en');
```

with modification:

```
translate.use(browserLang.match(/en|fr/) ? browserLang : translate.getDefaultLang());
```