### PR TITLE
feat(MissingTranslationHandler): pass additional paramaters to `handle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Just don't forget that it will be called synchronously from the `instant` method
 ##### Example:
 Create a Missing Translation Handler
 ```ts
-import {MissingTranslationHandler} from 'ng2-translate';
+import {MissingTranslationHandler, MissingTranslationHandlerParams} from 'ng2-translate';
 
 export class MyMissingTranslationHandler implements MissingTranslationHandler {
-  handle(key: string) {
+  handle(params: MissingTranslationHandlerParams) {
       return 'some value';
   }
 }

--- a/tests/translate.service.spec.ts
+++ b/tests/translate.service.spec.ts
@@ -4,6 +4,7 @@ import {MockBackend, MockConnection} from "@angular/http/testing";
 import {
     TranslateService,
     MissingTranslationHandler,
+    MissingTranslationHandlerParams,
     TranslateLoader,
     TranslateStaticLoader,
     LangChangeEvent,
@@ -304,14 +305,14 @@ describe('MissingTranslationHandler', () => {
     let missingTranslationHandler: MissingTranslationHandler;
 
     class Missing implements MissingTranslationHandler {
-        handle(key: string) {
+        handle(params: MissingTranslationHandlerParams) {
             return "handled";
         }
     }
 
     class MissingObs implements MissingTranslationHandler {
-        handle(key: string): Observable<any> {
-            return Observable.of(`handled: ${key}`);
+        handle(params: MissingTranslationHandlerParams): Observable<any> {
+            return Observable.of(`handled: ${params.key}`);
         }
     }
 
@@ -319,8 +320,8 @@ describe('MissingTranslationHandler', () => {
         TestBed.configureTestingModule({
             imports: [HttpModule, TranslateModule.forRoot()],
             providers: [
-                {provide: MissingTranslationHandler, useClass: handlerClass},
-                {provide: XHRBackend, useClass: MockBackend}
+                { provide: MissingTranslationHandler, useClass: handlerClass },
+                { provide: XHRBackend, useClass: MockBackend }
             ]
         });
         injector = getTestBed();
@@ -345,7 +346,40 @@ describe('MissingTranslationHandler', () => {
         spyOn(missingTranslationHandler, 'handle').and.callThrough();
 
         translate.get('nonExistingKey').subscribe((res: string) => {
-            expect(missingTranslationHandler.handle).toHaveBeenCalledWith('nonExistingKey');
+            expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'nonExistingKey' }));
+            //test that the instance of the last called argument is string 
+            expect(res).toEqual('handled');
+        });
+
+        // mock response after the xhr request, otherwise it will be undefined
+        mockBackendResponse(connection, '{"TEST": "This is a test"}');
+    });
+
+    it('should propagate interpolation params when the key does not exist', () => {
+        prepare(Missing);
+        translate.use('en');
+        spyOn(missingTranslationHandler, 'handle').and.callThrough();
+        let interpolateParams = { some: 'params' };
+
+        translate.get('nonExistingKey', interpolateParams).subscribe((res: string) => {
+            expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ interpolateParams: interpolateParams }));
+            //test that the instance of the last called argument is string 
+            expect(res).toEqual('handled');
+        });
+
+        // mock response after the xhr request, otherwise it will be undefined
+        mockBackendResponse(connection, '{"TEST": "This is a test"}');
+    });
+
+    it('should propagate TranslationService params when the key does not exist', () => {
+        prepare(Missing);
+        translate.use('en');
+        spyOn(missingTranslationHandler, 'handle').and.callThrough();
+        let interpolateParams = { some: 'params' };
+
+        translate.get('nonExistingKey', interpolateParams).subscribe((res: string) => {
+            expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ translateService: translate }));
+            //test that the instance of the last called argument is string 
             expect(res).toEqual('handled');
         });
 
@@ -355,7 +389,7 @@ describe('MissingTranslationHandler', () => {
 
     it('should return the key when using MissingTranslationHandler & the handler returns nothing', () => {
         class MissingUndef implements MissingTranslationHandler {
-            handle(key: string) {
+            handle(params: MissingTranslationHandlerParams) {
             }
         }
 
@@ -364,7 +398,7 @@ describe('MissingTranslationHandler', () => {
         spyOn(missingTranslationHandler, 'handle').and.callThrough();
 
         translate.get('nonExistingKey').subscribe((res: string) => {
-            expect(missingTranslationHandler.handle).toHaveBeenCalledWith('nonExistingKey');
+            expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'nonExistingKey' }));
             expect(res).toEqual('nonExistingKey');
         });
 
@@ -391,7 +425,7 @@ describe('MissingTranslationHandler', () => {
         spyOn(missingTranslationHandler, 'handle').and.callThrough();
 
         expect(translate.instant('nonExistingKey')).toEqual('handled');
-        expect(missingTranslationHandler.handle).toHaveBeenCalledWith('nonExistingKey');
+        expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'nonExistingKey' }));
     });
 
     it('should wait for the MissingTranslationHandler when it returns an observable & we use get', () => {
@@ -400,7 +434,7 @@ describe('MissingTranslationHandler', () => {
         spyOn(missingTranslationHandler, 'handle').and.callThrough();
 
         translate.get('nonExistingKey').subscribe((res: string) => {
-            expect(missingTranslationHandler.handle).toHaveBeenCalledWith('nonExistingKey');
+            expect(missingTranslationHandler.handle).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'nonExistingKey' }));
             expect(res).toEqual('handled: nonExistingKey');
         });
 


### PR DESCRIPTION
- pass `key`, `translateService`, and `interpolateParams` (if provided) to the `handle` method of `MissingTranslationHandler` for advanced  scenarios.
- `MissingTranslationHandler` README adjustments based on new function interface

Obsoletes #214, #230.
Closes #160, #221.
