### PR TITLE
Webpack example with ng2-translate 3.1.2

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -7,30 +7,32 @@
     "start": "webpack-dev-server --inline --progress --port 3000"
   },
   "dependencies": {
-    "@angular/common": "2.0.0-rc.5",
-    "@angular/compiler": "^2.0.0-rc.5",
-    "@angular/core": "2.0.0-rc.5",
-    "@angular/http": "2.0.0-rc.5",
-    "@angular/platform-browser": "2.0.0-rc.5",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
+    "@angular/common": "2.1.1",
+    "@angular/compiler": "^2.1.1",
+    "@angular/core": "2.1.1",
+    "@angular/http": "2.1.1",
+    "@angular/platform-browser": "2.1.1",
+    "@angular/platform-browser-dynamic": "2.1.1",
     "core-js": "2.4.1",
-    "ng2-translate": "2.4.2",
-    "rxjs": "5.0.0-beta.6",
-    "zone.js": "^0.6.12"
+    "ng2-translate": "3.1.2",
+    "rxjs": "5.0.0-beta.12",
+    "zone.js": "^0.6.26"
   },
   "devDependencies": {
-    "@types/core-js": "^0.9.31",
-    "@types/hammerjs": "^2.0.31",
-    "@types/node": "^6.0.36",
-    "angular2-template-loader": "^0.4.0",
-    "awesome-typescript-loader": "2.1.1",
-    "html-loader": "^0.4.0",
-    "html-webpack-plugin": "^2.8.1",
+    "@types/core-js": "^0.9.34",
+    "@types/hammerjs": "^2.0.33",
+    "@types/node": "^6.0.45",
+    "angular2-template-loader": "^0.5.0",
+    "awesome-typescript-loader": "2.2.4",
+    "babel-core": "^6.17.0",
+    "babel-loader": "^6.2.5",
+    "html-loader": "^0.4.4",
+    "html-webpack-plugin": "^2.23.0",
     "raw-loader": "0.5.1",
     "source-map-loader": "^0.1.5",
-    "ts-helpers": "^1.1.1",
-    "typescript": "2.0.0",
-    "webpack": "2.1.0-beta.20",
-    "webpack-dev-server": "1.14.1"
+    "ts-helpers": "^1.1.2",
+    "typescript": "2.0.3",
+    "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.16.2"
   }
 }

--- a/examples/webpack/src/app.component.ts
+++ b/examples/webpack/src/app.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TranslateService} from 'ng2-translate/ng2-translate';
+import {TranslateService} from 'ng2-translate';
 
 @Component({
     selector: 'my-app',
@@ -17,7 +17,7 @@ import {TranslateService} from 'ng2-translate/ng2-translate';
 })
 export class AppComponent {
     constructor(private translate: TranslateService) {
-        translate.addLangs(["en", "fr"]);
+        translate.addLangs(['en', 'fr']);
         translate.setDefaultLang('en');
 
         let browserLang = translate.getBrowserLang();

--- a/examples/webpack/src/app.module.ts
+++ b/examples/webpack/src/app.module.ts
@@ -1,8 +1,8 @@
-import {HttpModule} from "@angular/http";
-import {BrowserModule} from "@angular/platform-browser";
-import {NgModule} from "@angular/core";
-import {TranslateModule} from "ng2-translate/ng2-translate";
-import {AppComponent} from "./app.component";
+import {HttpModule} from '@angular/http';
+import {BrowserModule} from '@angular/platform-browser';
+import {NgModule} from '@angular/core';
+import {TranslateModule} from 'ng2-translate';
+import {AppComponent} from './app.component';
 
 @NgModule({
     imports: [

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -24,14 +24,13 @@ module.exports = {
     devtool: 'cheap-module-source-map',
 
     module: {
-        preLoaders: [{
-            test: /\.js$/,
-            loader: 'source-map'
-        }],
         loaders: [{
             test: /\.ts$/,
-            loader: 'awesome-typescript-loader',
-            exclude: /(node_modules)/
+            loader: 'awesome-typescript-loader'
+        }, {
+            test: /\.js$/,
+            loader: 'babel',
+            include: /node_modules\/ng2-translate/
         }]
     },
 


### PR DESCRIPTION
Hi,

this PR attempts to fix issues #258 and #273 with an updated webpack example that includes...
- ng2-translate 3.1.2
- Angular 2.1.1
- The fix (or dirty workaround?!) discussed in #273: loading ng2-translate with Babel
- Minor style changes
- Downgrade to a stable webpack version

Although this example works, I could not get rid of this warning:

```
WARNING in ./~/ng2-translate/bundles/ng2-translate.js
Critical dependencies:
58:100-107 require function is used in a way in which dependencies cannot be statically extracted
58:152-159 require function is used in a way in which dependencies cannot be statically extracted
 @ ./~/ng2-translate/bundles/ng2-translate.js 58:100-107 58:152-159
```

Anything missing?
