### PR TITLE
docs: update on how to use with NativeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,5 +314,5 @@ Ionic 2 is still using angular 2 RC4, but ng2-translate uses RC5. You should fix
 
 ## Additional Framework Support
 
-* [NativeScript](https://www.nativescript.org/) via [nativescript-ng2-translate](https://github.com/NathanWalker/nativescript-ng2-translate)
+* [Use with NativeScript](https://github.com/NathanWalker/nativescript-ng2-translate/issues/5#issuecomment-257606661)
 


### PR DESCRIPTION
The plugin is no longer needed since the feature it provided is now available in core. Just updates the note to point to a comment providing help on how to set it up.