### PR TITLE
Readme fixes for examples using pipe values

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ import {TranslateService} from 'ng2-translate';
 @Component({
     selector: 'app',
     template: `
-        <div>{{ 'HELLO' | translate:{value: param} }}</div>
+        <div>{{ 'HELLO' | translate:'{value: "' + param + '"}' }}</div>
     `
 })
 export class AppComponent {
@@ -183,7 +183,7 @@ translate.get('HELLO', {value: 'world'}).subscribe((res: string) => {
 And this is how you do it with the pipe.
 
 ```html
-<div>{{ 'HELLO' | translate:{value: param} }}</div>
+<div>{{ 'HELLO' | translate:'{value: "' + param + '"}' }}</div>
 ```
 
 #### 5. Use HTML tags:


### PR DESCRIPTION
The pipe examples using values gave me errors. Maybe it is an idea to also show an example of a regular string as value?
e.g.
<div>{{ 'HELLO' | translate:{value: "Some value"} }}</div>