### PR TITLE
Adding useful LocalizableTranslateStaticLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ export function createTranslateLoader(http: Http) {
 export class AppModule { }
 ```
 
+##### Localizations
+
+If you need to handle different localizations for the same language you can use the LocalizableTranslateStaticLoader. It allows you to manage different files (es.json, es-UY.json, es-US.json, ...) were each specific localization file overrides the keys of the default one.
+
+```ts
+export function createTranslateLoader(http: Http) {
+    return new LocalizableTranslateStaticLoader(http, './assets/i18n', '.json');
+}
+```
+
+Note: Remember to use the specific locale, e.g. `translate.use('es-UY');`
+
 #### 2. Init the `TranslateService` for your application:
 
 ```ts

--- a/src/translate.service.ts
+++ b/src/translate.service.ts
@@ -88,6 +88,56 @@ export class TranslateStaticLoader implements TranslateLoader {
     }
 }
 
+/**
+ * Able to handle different localizations for the same language.
+ * You can define for example es.json & es-UY.json overriding custom localizations in the latest
+ * (i.e. all the keys in es.json are going to be overriden by es-UY.json if the latest repeats them)
+ * E.g: es.json: { "currency": "Moneda", "currency-symbol": "$" }
+ * E.g: es-UY.json: { "currency-symbol": "$U" } -> only currency symbol is going to be overriden
+ * Additionally you need use the correct locale (i.e. _translateService.use('es-UY');)
+ */
+export class LocalizableTranslateStaticLoader implements TranslateLoader {
+    constructor(private http: Http, private prefix: string = "i18n", private suffix: string = ".json") {
+    }
+
+    /**
+     * Gets the base translation overriden by the localizations if corresponds
+     */
+    getTranslation(locale: string): Observable<any> {
+        let language = locale.split("-")[0];
+        if (language.length == 2) {
+            return Observable.forkJoin(
+                this.http.get(`${this.prefix}/${language}${this.suffix}`)
+                    .map((res: any) => res.json()),
+                this.http.get(`${this.prefix}/${locale}${this.suffix}`)
+                    .map((res: any) => res.json())
+            ).map((translations: any[]) => this.mergeRecursive(translations[0], translations[1]));
+        } else {
+            return this.http.get(`${this.prefix}/${locale}${this.suffix}`)
+                .map((res: any) => res.json());
+        }
+    }
+
+    private mergeRecursive(obj1: any, obj2: any) {
+        for (let p in obj2) {
+            try {
+                // Property in destination object set; update its value.
+                if (obj2[p].constructor == Object) {
+                    obj1[p] = this.mergeRecursive(obj1[p], obj2[p]);
+                } else {
+                    obj1[p] = obj2[p];
+                }
+            } catch(e) {
+                // Property in destination object not set; create it and set its value.
+                obj1[p] = obj2[p];
+            }
+        }
+
+        return obj1;
+    }
+
+}
+
 @Injectable()
 export class TranslateService {
     /**


### PR DESCRIPTION
In some situations you need to handle different localizations for the same language.
Initially I thought it was cover by:

```
_translateService.setDefaultLang("en");
_translateService.use("en-UK");
```

but certainly not, it just ignore all the keys of en, if they are not present on en-UK.
So after reading some issues without a clear solution I came up with this idea and thought I might worth to be shared because it sounds to be a common scenario and a good approach.

The provided loader if used will look for both files and override the keys of the generic translation with the localizations, so for example if you have:
es.json: { "currency": "Moneda", "currency-symbol": "$" }
and 
es-UY.json: { "currency-symbol": "$U" } -> only currency symbol is going to be override
es-AR.json: { "currency-symbol": "ARS" }
es-UK.json: { "currency-symbol": "£" }

all the translations of es.json are going to be available but just the repeated ones overriden, which is the common scenario on application localization. 