### PR TITLE
bug fix: uncaught error within TranslateService.use()

### DIFF
--- a/lib/src/translate.service.ts
+++ b/lib/src/translate.service.ts
@@ -207,7 +207,7 @@ export class TranslateService {
       pending.pipe(take(1))
         .subscribe((res: any) => {
           this.changeLang(lang);
-        });
+        }, err => { });
 
       return pending;
     } else { // we have this language, return an Observable


### PR DESCRIPTION
When use the `use()` method of `TranslateService` to load an invalid language, it will result nothing. For example, the file `assets/i18n/vvvv.json` does not exist, so the `"vvvv"` language is invalid:

```ts
this.translateService.use('vvvv').pipe(
  mapTo(true),
  catchError(() => Observable.of(false)),
).subscribe((isSuccess: boolean) => console.warn('isSuccess: ', isSuccess));
```

The code above will not output anything.

Because there is an uncaught error within the `use()` method:

```ts
      pending.pipe(take(1))
        .subscribe((res: any) => {
          this.changeLang(lang);
        });
```

If the language file is missing, this code will break the running, the other subscribers of `pending` will be halt, missing the data of `next()`, `error()` or `complete()`.

Adding a void error handler will fix this bug.