### PR TITLE
docs(README): reference light-localize-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ If you want to reload the translations and see the update on all your components
 
 ## Plugins
 - [Localize Router](https://github.com/Greentube/localize-router) by @meeroslav: An implementation of routes localization for Angular. If you need localized urls (for example /fr/page and /en/page).
+- [Light Localize Router](https://github.com/elham-oss/light-localize-router) by @elham-oss: localized routes without the need of rewriting your router configuration inspired by localize-routes & angular-l10n routing.
 - [.po files Loader](https://github.com/biesbjerg/ngx-translate-po-http-loader) by @biesbjerg: Use .po translation files with ngx-translate
 - [ngx-translate-extract](https://github.com/biesbjerg/ngx-translate-extract) by @biesbjerg: Extract translatable strings from your projects
 - [MessageFormat Compiler](https://github.com/lephyrus/ngx-translate-messageformat-compiler) by @lephyrus: Compiler for ngx-translate that uses messageformat.js to compile translations using ICU syntax for handling pluralization, gender, and more


### PR DESCRIPTION
we would like to share what we use in our projects need localized routes, we built another plugin for localized routes designed for angular 10 without the need of modifying angular router configurations. 