### PR TITLE
fix(service): prevent `use()` from throwing an "Uncaught" exception

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -215,9 +215,13 @@ export class TranslateService {
       }
 
       pending.pipe(take(1))
-        .subscribe((res: any) => {
-          this.changeLang(lang);
-        });
+        .subscribe(
+          (res: any) => {
+            this.changeLang(lang);
+          },
+          // prevent from throwing an unhandled exception
+          () => {}
+        );
 
       return pending;
     } else { // we have this language, return an Observable

--- a/projects/ngx-translate/core/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/core/tests/translate.service.spec.ts
@@ -1,6 +1,6 @@
 import {fakeAsync, TestBed, tick} from "@angular/core/testing";
-import {Observable, of, timer, zip, defer} from "rxjs";
-import {mapTo, take, toArray, first} from 'rxjs/operators';
+import {Observable, of, timer, zip, defer, throwError} from "rxjs";
+import {mapTo, take, toArray, first, catchError} from 'rxjs/operators';
 import {LangChangeEvent, TranslateLoader, TranslateModule, TranslateService, TranslationChangeEvent} from '../src/public_api';
 
 let translations: any = {"TEST": "This is a test"};
@@ -526,4 +526,14 @@ describe('TranslateService', () => {
 
     expect(translateCompilerCallCount).toBe(1);
   }));
+
+  it('should not throw unhandled exception', () => {
+    spyOn(translate.currentLoader, 'getTranslation').and.callFake(() => {
+      return throwError(new Error('Not found'));
+    });
+    translate.use('en').pipe(catchError(() => of({}))).subscribe();
+    window.onerror = function() {
+      fail('You have unhandled exceptions');
+    }
+  });
 });


### PR DESCRIPTION
Fixes #1280 