### PR TITLE
fix(TranslateService): load translations if they have not been loaded before (#1193)(#1266)

### DIFF
--- a/projects/ngx-translate/core/src/lib/translate.service.ts
+++ b/projects/ngx-translate/core/src/lib/translate.service.ts
@@ -202,8 +202,9 @@ export class TranslateService {
    */
   public use(lang: string): Observable<any> {
     // don't change the language if the language given is already selected
+    let changeLang = true;
     if (lang === this.currentLang) {
-      return of(this.translations[lang]);
+      changeLang = false;
     }
 
     let pending = this.retrieveTranslations(lang);
@@ -216,12 +217,16 @@ export class TranslateService {
 
       pending.pipe(take(1))
         .subscribe((res: any) => {
-          this.changeLang(lang);
+          if (changeLang) {
+            this.changeLang(lang);
+          }
         });
 
       return pending;
     } else { // we have this language, return an Observable
-      this.changeLang(lang);
+      if (changeLang) {
+        this.changeLang(lang);
+      }
 
       return of(this.translations[lang]);
     }


### PR DESCRIPTION
This PR contains no breaking changes.

When the `translateService.use(...)` method is called nothing happens if the current language is the same as the one passed as parameter. This causes that after changing the language in one instance of the translate service the rest of instances don't fetch the translations if they don't use isolate = true since the current language is the same as the one passed as parameter.  That is why workarounds like this
```
translateService.currentLang = '';
translateService.use ('en');
```
worked. Removing the first return statement leaves the service check if it has the translations and gets them if they have not been loaded before. It fixes (#1193)(#1266) between other issues I am not able to find now.