### PR TITLE
Fix extend module load

### DIFF
--- a/packages/core/lib/translate.service.ts
+++ b/packages/core/lib/translate.service.ts
@@ -161,18 +161,22 @@ export class TranslateService {
               @Inject(DEFAULT_LANGUAGE) defaultLanguage: string) {
     /** set the default language from configuration */
     if (defaultLanguage) {
-      this.setDefaultLang(defaultLanguage, this.extend);
+      this._setDefaultLang(defaultLanguage, this.extend);
     }
 
     if (this.extend) {
-      this.use(this.currentLang, true);
+      this._use(this.currentLang, true);
     }
   }
 
   /**
    * Sets the default language to use as a fallback
    */
-  public setDefaultLang(lang: string, forceLoad: boolean = false): void {
+  public setDefaultLang(lang: string): void {
+    this._setDefaultLang(lang);
+  }
+
+  protected _setDefaultLang(lang: string, forceLoad: boolean = false): void {
     if (lang === this.defaultLang && !forceLoad) {
       return;
     }
@@ -204,7 +208,11 @@ export class TranslateService {
   /**
    * Changes the lang currently used
    */
-  public use(lang: string, forceLoad: boolean = false): Observable<any> {
+  public use(lang: string): Observable<any> {
+    return this._use(lang);
+  }
+
+  protected _use(lang: string, forceLoad: boolean = false): Observable<any> {
     // don't change the language if the language given is already selected
     if (lang === this.currentLang && !forceLoad) {
       return of(this.translations[lang]);

--- a/packages/core/lib/translate.service.ts
+++ b/packages/core/lib/translate.service.ts
@@ -161,19 +161,23 @@ export class TranslateService {
               @Inject(DEFAULT_LANGUAGE) defaultLanguage: string) {
     /** set the default language from configuration */
     if (defaultLanguage) {
-      this.setDefaultLang(defaultLanguage);
+      this.setDefaultLang(defaultLanguage, this.extend);
+    }
+
+    if (this.extend) {
+      this.use(this.currentLang);
     }
   }
 
   /**
    * Sets the default language to use as a fallback
    */
-  public setDefaultLang(lang: string): void {
-    if (lang === this.defaultLang) {
+  public setDefaultLang(lang: string, forceLoad: boolean = false): void {
+    if (lang === this.defaultLang && !forceLoad) {
       return;
     }
 
-    let pending = this.retrieveTranslations(lang);
+    let pending = this.retrieveTranslations(lang, forceLoad);
 
     if (typeof pending !== "undefined") {
       // on init set the defaultLang immediately
@@ -200,13 +204,13 @@ export class TranslateService {
   /**
    * Changes the lang currently used
    */
-  public use(lang: string): Observable<any> {
+  public use(lang: string, forceLoad: boolean = false): Observable<any> {
     // don't change the language if the language given is already selected
-    if (lang === this.currentLang) {
+    if (lang === this.currentLang && !forceLoad) {
       return of(this.translations[lang]);
     }
 
-    let pending = this.retrieveTranslations(lang);
+    let pending = this.retrieveTranslations(lang, forceLoad);
 
     if (typeof pending !== "undefined") {
       // on init set the currentLang immediately
@@ -230,7 +234,11 @@ export class TranslateService {
   /**
    * Retrieves the given translations
    */
-  private retrieveTranslations(lang: string): Observable<any> | undefined {
+  private retrieveTranslations(lang: string, forceLoad: boolean = false): Observable<any> | undefined {
+    if (forceLoad) {
+      return this.getTranslation(lang);
+    }
+
     let pending: Observable<any> | undefined;
 
     // if this language is unavailable or extend is true, ask for it

--- a/packages/core/lib/translate.service.ts
+++ b/packages/core/lib/translate.service.ts
@@ -165,7 +165,7 @@ export class TranslateService {
     }
 
     if (this.extend) {
-      this.use(this.currentLang);
+      this.use(this.currentLang, true);
     }
   }
 


### PR DESCRIPTION
On the constructor if is extended it will force load the default and the current language.
Possible fix for #1266 