### PR TITLE
feat(http-loader): ressources

### DIFF
--- a/projects/http-loader/src/lib/http-loader.spec.ts
+++ b/projects/http-loader/src/lib/http-loader.spec.ts
@@ -74,8 +74,23 @@ describe("TranslateHttpLoader (HttpClient)", () => {
             expect(true).toBeTruthy(); // http.expectOne() is not detected by jasmine...
         });
 
+        it("uses multipleHttpLoader prefix", () => {
+            prepareMulti({ resources: ["XXXX/", "YYYY/"] });
+            translate.use("en");
+            http.expectOne("XXXX/en.json").flush({});
+            http.expectOne("YYYY/en.json").flush({});
+            expect(true).toBeTruthy(); // http.expectOne() is not detected by jasmine...
+        });
+
         it("uses suffix", () => {
             prepareSingle({ suffix: ".XXXX" });
+            translate.use("en");
+            http.expectOne("/assets/i18n/en.XXXX").flush({});
+            expect(true).toBeTruthy(); // http.expectOne() is not detected by jasmine...
+        });
+
+        it("uses multipleHttpLoader suffix", () => {
+            prepareMulti({ resources: [{ prefix: "/assets/i18n/", suffix: ".XXXX" }] });
             translate.use("en");
             http.expectOne("/assets/i18n/en.XXXX").flush({});
             expect(true).toBeTruthy(); // http.expectOne() is not detected by jasmine...
@@ -113,6 +128,28 @@ describe("TranslateHttpLoader (HttpClient)", () => {
         });
     });
 
+    it("should be able to get translations from multipleHttpLoader", () => {
+        prepareMulti();
+
+        translate.use("en");
+
+        // this will request the translation from the backend because we use a static files loader for TranslateService
+        translate.get("TEST").subscribe((res: Translation) => {
+            expect(res as string).toEqual("This is a test");
+        });
+
+        // mock response after the xhr request, otherwise it will be undefined
+        http.expectOne("/assets/i18n/en.json").flush({
+            TEST: "This is a test",
+            TEST2: "This is another test",
+        });
+
+        // this will request the translation from downloaded translations without making a request to the backend
+        translate.get("TEST2").subscribe((res: Translation) => {
+            expect(res as string).toEqual("This is another test");
+        });
+    });
+
     it("should trigger MarkerInterceptor when loading translations", () => {
         prepareSingle();
 
@@ -124,8 +161,40 @@ describe("TranslateHttpLoader (HttpClient)", () => {
         expect(req.request.headers.get("X-Test-Header")).toBe("marker");
     });
 
+    it("should trigger MarkerInterceptor when loading translations with multipleHttpLoader", () => {
+        prepareMulti();
+
+        translate.use("en").subscribe();
+
+        const req = http.expectOne("/assets/i18n/en.json");
+        req.flush({ HELLO: "Hello" });
+
+        expect(req.request.headers.get("X-Test-Header")).toBe("marker");
+    });
+
     it("should be able to reload a lang", () => {
         prepareSingle();
+
+        translate.use("en");
+
+        // this will request the translation from the backend because we use a static files loader for TranslateService
+        translate.get("TEST").subscribe((res: Translation) => {
+            expect(res as string).toEqual("This is a test");
+
+            // reset the lang as if it was never initiated
+            translate.reloadLang("en").subscribe(() => {
+                expect(translate.instant("TEST") as string).toEqual("This is a test 2");
+            });
+
+            http.expectOne("/assets/i18n/en.json").flush({ TEST: "This is a test 2" });
+        });
+
+        // mock response after the xhr request, otherwise it will be undefined
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "This is a test" });
+    });
+
+    it("should be able to reload a lang with multipleHttpLoader", () => {
+        prepareMulti();
 
         translate.use("en");
 
@@ -173,5 +242,105 @@ describe("TranslateHttpLoader (HttpClient)", () => {
 
         // mock response after the xhr request, otherwise it will be undefined
         http.expectOne("/assets/i18n/en.json").flush({ TEST: "This is a test" });
+    });
+
+    it("should be able to reset a lang from MultiHttpLoader", (done: DoneFn) => {
+        prepareMulti();
+
+        translate.use("en");
+        spyOn(http, "expectOne").and.callThrough();
+
+        // this will request the translation from the backend because we use a static files loader for TranslateService
+        translate.get("TEST").subscribe((res: Translation) => {
+            expect(res as string).toEqual("This is a test");
+            expect(http.expectOne).toHaveBeenCalledTimes(1);
+
+            // reset the lang as if it was never initiated
+            translate.resetLang("en");
+
+            expect(translate.instant("TEST") as string).toEqual("TEST");
+
+            // use set timeout because no request is really made and we need to trigger zone to resolve the observable
+            setTimeout(() => {
+                translate.get("TEST").subscribe((res2: Translation) => {
+                    expect(res2 as string).toEqual("TEST"); // because the loader is "pristine" as if it was never called
+                    expect(http.expectOne).toHaveBeenCalledTimes(1);
+                    done();
+                });
+            }, 10);
+        });
+
+        // mock response after the xhr request, otherwise it will be undefined
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "This is a test" });
+    });
+
+    it("should merge translations from multiple resources", () => {
+        prepareMulti({
+            resources: ["/assets/i18n/", { prefix: "/custom/", suffix: ".lang.json" }],
+        });
+        translate.use("en").subscribe();
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "A", ONLY1: "X" });
+        http.expectOne("/custom/en.lang.json").flush({ TEST: "B", ONLY2: "Y" });
+        // TEST should be overwritten by the second resource
+        expect(translate.instant("TEST")).toBe("B");
+        expect(translate.instant("ONLY1")).toBe("X");
+        expect(translate.instant("ONLY2")).toBe("Y");
+    });
+
+    it("should handle error in one resource and still merge others", () => {
+        prepareMulti({
+            resources: ["/assets/i18n/", { prefix: "/custom/", suffix: ".lang.json" }],
+        });
+        translate.use("en").subscribe();
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "A" });
+        http.expectOne("/custom/en.lang.json").flush(null, {
+            status: 500,
+            statusText: "Server Error",
+        });
+        expect(translate.instant("TEST")).toBe("A");
+    });
+
+    it("should log error if showLog is true", () => {
+        prepareMulti({
+            resources: [
+                "/assets/i18n/",
+                { prefix: "/custom/", suffix: ".lang.json", showLog: true },
+            ],
+            showLog: true,
+        });
+        spyOn(console, "error");
+        translate.use("en").subscribe();
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "A" });
+        http.expectOne("/custom/en.lang.json").flush(null, {
+            status: 500,
+            statusText: "Server Error",
+        });
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it("should fallback to empty object if all resources fail", () => {
+        prepareMulti({
+            resources: ["/assets/i18n/", { prefix: "/custom/", suffix: ".lang.json" }],
+        });
+        translate.use("en").subscribe();
+        http.expectOne("/assets/i18n/en.json").flush(null, {
+            status: 500,
+            statusText: "Server Error",
+        });
+        http.expectOne("/custom/en.lang.json").flush(null, {
+            status: 500,
+            statusText: "Server Error",
+        });
+        expect(translate.instant("ANY")).toBe("ANY");
+    });
+
+    it("should support resource as string and object with suffix", () => {
+        prepareMulti({
+            resources: ["/assets/i18n/", { prefix: "/custom/", suffix: ".lang.json" }],
+        });
+        translate.use("en").subscribe();
+        http.expectOne("/assets/i18n/en.json").flush({ TEST: "A" });
+        http.expectOne("/custom/en.lang.json").flush({ TEST: "B" });
+        expect(translate.instant("TEST")).toBe("B");
     });
 });

--- a/projects/http-loader/src/lib/http-loader.ts
+++ b/projects/http-loader/src/lib/http-loader.ts
@@ -108,7 +108,10 @@ export function provideTranslateMultiHttpLoader(
     return [
         {
             provide: TRANSLATE_HTTP_LOADER_CONFIG,
-            useValue: config,
+            useValue: {
+                resources: ["/assets/i18n/"],
+                ...config,
+            },
         },
         {
             provide: TranslateLoader,

--- a/projects/test-app/public/i18n/another/de.json
+++ b/projects/test-app/public/i18n/another/de.json
@@ -1,5 +1,5 @@
 {
-  "multi": {
-    "loader": "Dieser Text wurde aus /i18n/another/de.json geladen"
-  }
+    "multi": {
+        "loader": "Dieser Text wurde aus /i18n/another/de.json geladen"
+    }
 }

--- a/projects/test-app/public/i18n/another/de.json
+++ b/projects/test-app/public/i18n/another/de.json
@@ -1,0 +1,5 @@
+{
+  "multi": {
+    "loader": "Dieser Text wurde aus /i18n/another/de.json geladen"
+  }
+}

--- a/projects/test-app/public/i18n/another/en.json
+++ b/projects/test-app/public/i18n/another/en.json
@@ -1,0 +1,5 @@
+{
+  "multi": {
+    "loader": "This text was loaded from /i18n/another/en.json"
+  }
+}

--- a/projects/test-app/public/i18n/another/en.json
+++ b/projects/test-app/public/i18n/another/en.json
@@ -1,5 +1,5 @@
 {
-  "multi": {
-    "loader": "This text was loaded from /i18n/another/en.json"
-  }
+    "multi": {
+        "loader": "This text was loaded from /i18n/another/en.json"
+    }
 }

--- a/projects/test-app/src/app/app.config.ts
+++ b/projects/test-app/src/app/app.config.ts
@@ -12,10 +12,8 @@ export const appConfig: ApplicationConfig = {
         provideHttpClient(),
         provideTranslateService({
             loader: provideTranslateHttpLoader({
-                prefix: "./i18n/",
-                suffix: ".json",
                 enforceLoading: true,
-                ressources: [{ prefix: "./i18n/another/", suffix: ".json" }, { prefix: "./i18n/" }],
+                resources: [{ prefix: "./i18n/another/", suffix: ".json" }, { prefix: "./i18n/" }],
             }),
         }),
     ],

--- a/projects/test-app/src/app/app.config.ts
+++ b/projects/test-app/src/app/app.config.ts
@@ -15,6 +15,7 @@ export const appConfig: ApplicationConfig = {
                 prefix: "./i18n/",
                 suffix: ".json",
                 enforceLoading: true,
+                ressources: [{ prefix: "./i18n/another/", suffix: ".json" }, { prefix: "./i18n/" }],
             }),
         }),
     ],

--- a/projects/test-app/src/app/app.config.ts
+++ b/projects/test-app/src/app/app.config.ts
@@ -15,10 +15,7 @@ export const appConfig: ApplicationConfig = {
                 prefix: "./i18n/",
                 suffix: ".json",
                 enforceLoading: true,
-                ressources: [
-                    { prefix: "./i18n/another/", suffix: ".json" },
-                    { prefix: "./i18n/awld" },
-                ],
+                ressources: [{ prefix: "./i18n/another/", suffix: ".json" }, { prefix: "./i18n/" }],
             }),
         }),
     ],

--- a/projects/test-app/src/app/app.config.ts
+++ b/projects/test-app/src/app/app.config.ts
@@ -15,7 +15,10 @@ export const appConfig: ApplicationConfig = {
                 prefix: "./i18n/",
                 suffix: ".json",
                 enforceLoading: true,
-                ressources: [{ prefix: "./i18n/another/", suffix: ".json" }, { prefix: "./i18n/" }],
+                ressources: [
+                    { prefix: "./i18n/another/", suffix: ".json" },
+                    { prefix: "./i18n/awld" },
+                ],
             }),
         }),
     ],

--- a/projects/test-app/src/app/components/page-content/page-content.component.html
+++ b/projects/test-app/src/app/components/page-content/page-content.component.html
@@ -1,5 +1,7 @@
 <div class="title">
-    <h1>{{ "demo.title" | translate }}</h1>
+    <h1>
+        {{ "demo.title" | translate }}
+    </h1>
 </div>
 <div>
     <h2>Simple translations without parameters</h2>
@@ -10,3 +12,8 @@
 </div>
 
 <app-standalone-component />
+
+<div class="multi-loader">
+    <h2>Http-loader: Ressources</h2>
+    <p>{{ "multi.loader" | translate }}</p>
+</div>

--- a/projects/test-app/src/styles.scss
+++ b/projects/test-app/src/styles.scss
@@ -66,6 +66,10 @@ p,
         background-color: var(--mat-sys-surface-dim);
         border-radius: var(--mat-sys-corner-small);
         padding: var(--space) var(--space-small);
+
+        em {
+            font-size: small;
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Enable loading multiple ressources with the default http-loader.  
Also add a `showLog` mode, which let use show, or not, the console.log error on missing file request

## Note
- It does accept `ressources: ['/i18n/first', '/i18n/second]` and `ressources: [prefix: { '/i18n/first'}]`
- If ressources is given, it does ignore the initial `suffix` and `prefix`.
- `showLog: boolean` shall be given, defaulted to false