### PR TITLE
feat(store): initialized$

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, InjectionToken } from "@angular/core";
-import { concat, defer, forkJoin, isObservable, Observable, of } from "rxjs";
-import { concatMap, map, shareReplay, switchMap, take } from "rxjs/operators";
+import { concat, defer, firstValueFrom, forkJoin, isObservable, Observable, of } from "rxjs";
+import { concatMap, filter, map, shareReplay, switchMap, take } from "rxjs/operators";
 import { MissingTranslationHandler } from "./missing-translation-handler";
 import { TranslateCompiler } from "./translate.compiler";
 import { TranslateLoader } from "./translate.loader";
@@ -604,11 +604,18 @@ export class TranslateService implements ITranslateService {
     /**
      * Sets the translated value of a key, after compiling it
      */
-    public set(
+    public async set(
         key: string,
         translation: string | TranslationObject,
         lang: Language = this.getCurrentLang(),
-    ): void {
+    ): Promise<void> {
+        await firstValueFrom(
+            this.store.initialized$.pipe(
+                filter((event) => (event ? true : false)),
+                take(1),
+            ),
+        );
+
         this.store.setTranslations(
             lang,
             insertValue(

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,14 +1,14 @@
-import {
-    InterpolatableTranslationObject,
-    FallbackLangChangeEvent,
-    LangChangeEvent,
-    TranslationChangeEvent,
-    Language,
-    InterpolatableTranslation,
-} from "./translate.service";
-import { Observable, Subject } from "rxjs";
-import { getValue, mergeDeep } from "./util";
 import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable, Subject } from "rxjs";
+import {
+    FallbackLangChangeEvent,
+    InterpolatableTranslation,
+    InterpolatableTranslationObject,
+    LangChangeEvent,
+    Language,
+    TranslationChangeEvent,
+} from "./translate.service";
+import { getValue, mergeDeep } from "./util";
 
 export type DeepReadonly<T> = {
     readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
@@ -28,6 +28,8 @@ export class TranslateStore {
     private translations: Record<Language, InterpolatableTranslationObject> = {};
     private languages: Language[] = [];
 
+    initialized$ = new BehaviorSubject(false);
+
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
         return this.translations[language];
     }
@@ -46,6 +48,10 @@ export class TranslateStore {
             lang: language,
             translations: this.getTranslations(language),
         });
+
+        if (!this.initialized$.getValue()) {
+            this.initialized$.next(true);
+        }
     }
 
     public getLanguages(): readonly Language[] {

--- a/projects/ngx-translate/src/tests/translate.compiler.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.compiler.spec.ts
@@ -4,14 +4,14 @@ import { Observable, of } from "rxjs";
 import {
     InterpolatableTranslationObject,
     TranslateCompiler,
-    TranslateNoOpCompiler,
     TranslateLoader,
+    TranslateNoOpCompiler,
     TranslateService,
     Translation,
     TranslationObject,
-    provideTranslateService,
-    provideTranslateLoader,
     provideTranslateCompiler,
+    provideTranslateLoader,
+    provideTranslateService,
 } from "../public-api";
 
 const translations: TranslationObject = { LOAD: "This is a test" };
@@ -58,8 +58,8 @@ describe("TranslateCompiler", () => {
             expect(translate.instant("SET-TRANSLATION")).toBe("A manually added translation");
         });
 
-        it("should use the compiler on manually adding a single translation", () => {
-            translate.set("SET", "Another manually added translation", "en");
+        it("should use the compiler on manually adding a single translation", async () => {
+            await translate.set("SET", "Another manually added translation", "en");
             expect(translate.instant("SET")).toBe("Another manually added translation");
         });
     });
@@ -118,8 +118,8 @@ describe("TranslateCompiler", () => {
             );
         });
 
-        it("should use the compiler on manually adding a single translation", () => {
-            translate.set("SET", "Another manually added translation", "en");
+        it("should use the compiler on manually adding a single translation", async () => {
+            await translate.set("SET", "Another manually added translation", "en");
             expect(translate.instant("SET")).toBe("Another manually added translation|compiled");
         });
     });

--- a/projects/ngx-translate/src/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.service.spec.ts
@@ -612,17 +612,17 @@ describe("TranslateService", () => {
     });
 
     describe("set()", () => {
-        it("should set translations with nested key (string)", () => {
+        it("should set translations with nested key (string)", async () => {
             translate.setTranslation("en", { profile: "test" });
             translate.use("en");
-            translate.set("profile.name", "Profile Name", "en");
+            await translate.set("profile.name", "Profile Name", "en");
             expect(translate.instant("profile.name")).toEqual("Profile Name");
         });
 
-        it("should set translations with nested key (object)", () => {
+        it("should set translations with nested key (object)", async () => {
             translate.setTranslation("en", { profile: "test" });
             translate.use("en");
-            translate.set("a.b", { c: { d: "setting nested object" } }, "en");
+            await translate.set("a.b", { c: { d: "setting nested object" } }, "en");
             expect(translate.instant("a.b.c.d")).toEqual("setting nested object");
         });
 


### PR DESCRIPTION
## Description
I've noticed that we aren't waiting the httpLoader before doing any data mutation, this does create the following error: 

- https://github.com/ngx-translate/core/issues/884
- https://github.com/ngx-translate/core/issues/758

## Do
We're now waiting for the initialized$ to be triggered, before letting using use the `set()` method.   
This later also has been transformed to a Promises, letting people be sure the value is set before moving forward (you can see this in the test).

## Note
We could surely fix other problem with this logic, but I'd prefer to do small PRs

