### PR TITLE
feat(store): loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ interfaces and explains how to develop custom plugins.
 - [Migration guide ngx-translate v16 -> v17](https://ngx-translate.org/getting-started/migration-guide/)
 - [Release Notes](https://github.com/ngx-translate/core/releases)
 
-In addition to that, a getting started tutorial is available here: 
+In addition to that, a getting started tutorial is available here:
 [How to Translate Your Angular App with NGX-Translate](https://www.codeandweb.com/babeledit/tutorials/how-to-translate-your-angular-app-with-ngx-translate)
 
 ## Support for older versions

--- a/projects/http-loader/src/lib/http-loader-backend.spec.ts
+++ b/projects/http-loader/src/lib/http-loader-backend.spec.ts
@@ -1,12 +1,16 @@
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
-import { provideTranslateService, TranslateService, Translation } from "@ngx-translate/core";
+import { TranslateService, Translation } from "@ngx-translate/core";
 import { provideTranslateHttpLoader, TranslateHttpLoader } from "../public-api";
 import { MarkerInterceptor } from "../test-helper/marker-interceptor";
+import {
+    provideTestableTranslateService,
+    TestableTranslateService,
+} from "../test-helper/testable-translate-service";
 
 describe("TranslateHttpLoader (HttpBackend)", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
     let http: HttpTestingController;
 
     beforeEach(() => {
@@ -20,14 +24,15 @@ describe("TranslateHttpLoader (HttpBackend)", () => {
                 },
                 provideHttpClient(withInterceptorsFromDi()),
                 provideHttpClientTesting(),
-                provideTranslateService(),
-                provideTranslateHttpLoader({
-                    useHttpBackend: true,
+                provideTestableTranslateService({
+                    loader: provideTranslateHttpLoader({
+                        useHttpBackend: true,
+                    }),
                 }),
             ],
         });
 
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
         http = TestBed.inject(HttpTestingController);
     });
 
@@ -37,8 +42,8 @@ describe("TranslateHttpLoader (HttpBackend)", () => {
 
     it("should be able to provide TranslateHttpLoader", () => {
         expect(TranslateHttpLoader).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof TranslateHttpLoader).toBeTruthy();
+        expect(translate.getCurrentLoader()).toBeDefined();
+        expect(translate.getCurrentLoader() instanceof TranslateHttpLoader).toBeTruthy();
     });
 
     it("should be able to get translations", () => {

--- a/projects/http-loader/src/lib/http-loader.spec.ts
+++ b/projects/http-loader/src/lib/http-loader.spec.ts
@@ -1,7 +1,7 @@
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
-import { provideTranslateService, TranslateService, Translation } from "@ngx-translate/core";
+import { TranslateService, Translation } from "@ngx-translate/core";
 import {
     provideTranslateHttpLoader,
     provideTranslateMultiHttpLoader,
@@ -10,9 +10,13 @@ import {
     TranslateMultiHttpLoaderConfig,
 } from "../public-api";
 import { MarkerInterceptor } from "../test-helper/marker-interceptor";
+import {
+    provideTestableTranslateService,
+    TestableTranslateService,
+} from "../test-helper/testable-translate-service";
 
 describe("TranslateHttpLoader (HttpClient)", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
     let http: HttpTestingController;
 
     const prepareMulti = (config: Partial<TranslateMultiHttpLoaderConfig> = {}) => {
@@ -26,12 +30,13 @@ describe("TranslateHttpLoader (HttpClient)", () => {
                 },
                 provideHttpClient(withInterceptorsFromDi()),
                 provideHttpClientTesting(),
-                provideTranslateService(),
-                provideTranslateMultiHttpLoader(config),
+                provideTestableTranslateService({
+                    loader: provideTranslateMultiHttpLoader(config),
+                }),
             ],
         });
 
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
         http = TestBed.inject(HttpTestingController);
     };
 
@@ -46,12 +51,13 @@ describe("TranslateHttpLoader (HttpClient)", () => {
                 },
                 provideHttpClient(withInterceptorsFromDi()),
                 provideHttpClientTesting(),
-                provideTranslateService(),
-                provideTranslateHttpLoader(config),
+                provideTestableTranslateService({
+                    loader: provideTranslateHttpLoader(config),
+                }),
             ],
         });
 
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
         http = TestBed.inject(HttpTestingController);
     };
 
@@ -62,8 +68,8 @@ describe("TranslateHttpLoader (HttpClient)", () => {
     it("should be able to provide TranslateHttpLoader", () => {
         prepareSingle();
         expect(TranslateHttpLoader).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof TranslateHttpLoader).toBeTruthy();
+        expect(translate.getCurrentLoader()).toBeDefined();
+        expect(translate.getCurrentLoader() instanceof TranslateHttpLoader).toBeTruthy();
     });
 
     describe("Config", () => {

--- a/projects/http-loader/src/test-helper/testable-translate-service.ts
+++ b/projects/http-loader/src/test-helper/testable-translate-service.ts
@@ -1,38 +1,11 @@
-import { ClassProvider, Injectable, Provider } from "@angular/core";
-import { Observable, of, timer } from "rxjs";
-import { map } from "rxjs/operators";
+import { ClassProvider, Provider } from "@angular/core";
 import {
     provideTranslateService,
     RootTranslateServiceConfig,
     TranslateCompiler,
     TranslateLoader,
     TranslateService,
-    TranslationObject,
-} from "../public-api";
-
-@Injectable()
-export class DelayedFakeLoader implements TranslateLoader {
-    getTranslation(lang: string): Observable<TranslationObject> {
-        const translations: Record<string, TranslationObject> = {
-            en: { TEST: "This is a test" },
-            fr: { TEST: "C'est un test" },
-        };
-
-        return timer(9).pipe(map(() => translations[lang]));
-    }
-}
-
-@Injectable()
-export class FakeLoader implements TranslateLoader {
-    getTranslation(lang: string): Observable<TranslationObject> {
-        const translations: Record<string, TranslationObject> = {
-            en: { TEST: "This is a test" },
-            fr: { TEST: "C'est un test" },
-        };
-
-        return of(translations[lang]);
-    }
-}
+} from "@ngx-translate/core";
 
 export class TestableTranslateService extends TranslateService {
     public getCurrentLoader(): TranslateLoader {

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -179,8 +179,8 @@ export class TranslateService implements ITranslateService, OnDestroy {
     private _translationRequests: Record<Language, Observable<TranslationObject>> = {};
     private lastUseLanguage: Language | null = null;
 
-    public currentLoader = inject(TranslateLoader);
-    public compiler = inject(TranslateCompiler);
+    protected currentLoader = inject(TranslateLoader);
+    protected compiler = inject(TranslateCompiler);
     private parser = inject(TranslateParser);
     private missingTranslationHandler = inject(MissingTranslationHandler);
     private store: TranslateStore = inject(TranslateStore);

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -185,8 +185,6 @@ export class TranslateService implements ITranslateService, OnDestroy {
     private missingTranslationHandler = inject(MissingTranslationHandler);
     private store: TranslateStore = inject(TranslateStore);
 
-    private _loaderIndex!: number;
-
     private readonly extend: boolean = false;
 
     /**
@@ -227,8 +225,6 @@ export class TranslateService implements ITranslateService, OnDestroy {
     }
 
     constructor() {
-        this._loaderIndex = this.store.addLoader(inject(TranslateLoader));
-
         const config: TranslateServiceConfig = {
             extend: false,
             fallbackLang: null,
@@ -249,10 +245,12 @@ export class TranslateService implements ITranslateService, OnDestroy {
         if (config.extend) {
             this.extend = true;
         }
+
+        this.store.addLoader(this.currentLoader);
     }
 
-    ngOnDestroy() {
-        this.store.removeLoader(this._loaderIndex);
+    ngOnDestroy(): void {
+        this.store.removeLoader(this.currentLoader);
     }
 
     /**
@@ -350,28 +348,24 @@ export class TranslateService implements ITranslateService, OnDestroy {
         this.pending = true;
 
         const loaders = this.store.getLoaders();
-        if (loaders.size === 0) return of({} as InterpolatableTranslationObject);
+        let loadAndMerge: Observable<TranslationObject>;
 
-        const requests: Observable<TranslationObject>[] = [];
-        loaders.forEach((loader) => {
-            requests.push(loader.getTranslation(lang).pipe(take(1)));
-        });
+        if (loaders.length === 0) {
+            return of({} as InterpolatableTranslationObject);
+        } else if (loaders.length === 1) {
+            loadAndMerge = loaders[0].getTranslation(lang);
+        } else {
+            const requests: Observable<TranslationObject>[] = loaders.map((loader) =>
+                loader.getTranslation(lang).pipe(take(1)),
+            );
+            loadAndMerge = forkJoin(requests).pipe(
+                map((results: TranslationObject[]) =>
+                    results.reduce((acc, curr) => mergeDeep(acc, curr), {} as TranslationObject),
+                ),
+            );
+        }
 
-        // Merge all translation objects
-        const loadingTranslations = (
-            requests.length > 1
-                ? forkJoin(requests).pipe(
-                      map((results: TranslationObject[]) =>
-                          results.reduce(
-                              (acc, curr) => mergeDeep(acc, curr),
-                              {} as TranslationObject,
-                          ),
-                      ),
-                  )
-                : requests[0]
-        ).pipe(shareReplay(1), take(1));
-
-        this.loadingTranslations = loadingTranslations.pipe(
+        this.loadingTranslations = loadAndMerge.pipe(shareReplay(1), take(1)).pipe(
             map((res: TranslationObject) => this.compiler.compileTranslations(res, lang)),
             shareReplay(1),
             take(1),
@@ -388,7 +382,7 @@ export class TranslateService implements ITranslateService, OnDestroy {
             },
         });
 
-        return loadingTranslations;
+        return this.loadingTranslations;
     }
 
     /**

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -227,7 +227,7 @@ export class TranslateService implements ITranslateService, OnDestroy {
     }
 
     constructor() {
-        this._addLoader();
+        this._loaderIndex = this.store.addLoader();
 
         const config: TranslateServiceConfig = {
             extend: false,
@@ -251,15 +251,8 @@ export class TranslateService implements ITranslateService, OnDestroy {
         }
     }
 
-    private _addLoader() {
-        while (this.store.loaders.has(this._loaderIndex)) {
-            this._loaderIndex++;
-        }
-        this.store.loaders.set(this._loaderIndex, this.currentLoader);
-    }
-
     ngOnDestroy() {
-        this.store.loaders.delete(this._loaderIndex);
+        this.store.removeLoader(this._loaderIndex);
     }
 
     /**

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -227,7 +227,7 @@ export class TranslateService implements ITranslateService, OnDestroy {
     }
 
     constructor() {
-        this._loaderIndex = this.store.addLoader();
+        this._loaderIndex = this.store.addLoader(inject(TranslateLoader));
 
         const config: TranslateServiceConfig = {
             extend: false,
@@ -349,8 +349,13 @@ export class TranslateService implements ITranslateService, OnDestroy {
     ): Observable<InterpolatableTranslationObject> {
         this.pending = true;
 
-        const loaders = Array.from(this.store.loaders.values());
-        const requests = loaders.map((loader) => loader.getTranslation(lang).pipe(take(1)));
+        const loaders = this.store.getLoaders();
+        if (loaders.size === 0) return of({} as InterpolatableTranslationObject);
+
+        const requests: Observable<TranslationObject>[] = [];
+        loaders.forEach((loader) => {
+            requests.push(loader.getTranslation(lang).pipe(take(1)));
+        });
 
         // Merge all translation objects
         const loadingTranslations = (

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
+import { TranslateLoader } from "./translate.loader";
 import {
     FallbackLangChangeEvent,
     InterpolatableTranslation,
@@ -27,6 +28,8 @@ export class TranslateStore {
 
     private translations: Record<Language, InterpolatableTranslationObject> = {};
     private languages: Language[] = [];
+
+    loaders = new Map<number, TranslateLoader>();
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
         return this.translations[language];
@@ -72,6 +75,7 @@ export class TranslateStore {
 
     public setCurrentLang(lang: string, emitChange = true): void {
         this.currentLang = lang;
+
         if (emitChange) {
             this._onLangChange.next({ lang: lang, translations: this.translations[lang] });
         }

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -29,7 +29,7 @@ export class TranslateStore {
     private translations: Record<Language, InterpolatableTranslationObject> = {};
     private languages: Language[] = [];
 
-    loaders = new Map<number, TranslateLoader>();
+    private loaders = new Map<number, TranslateLoader>();
 
     /**
      * Adds a new loader to the store

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,6 +1,5 @@
 import { Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
-import { TranslateLoader } from "./translate.loader";
 import {
     FallbackLangChangeEvent,
     InterpolatableTranslation,
@@ -10,10 +9,16 @@ import {
     TranslationChangeEvent,
 } from "./translate.service";
 import { getValue, mergeDeep } from "./util";
+import { TranslateLoader } from "./translate.loader";
 
 export type DeepReadonly<T> = {
     readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
 };
+
+interface LoaderReference {
+    loader: TranslateLoader;
+    count: number;
+}
 
 @Injectable()
 export class TranslateStore {
@@ -29,27 +34,33 @@ export class TranslateStore {
     private translations: Record<Language, InterpolatableTranslationObject> = {};
     private languages: Language[] = [];
 
-    private loaders = new Map<number, TranslateLoader>();
+    private loaders: LoaderReference[] = [];
 
-    /**
-     * Adds a new loader to the store
-     * @returns the index of the newly added loader
-     */
-    addLoader(loader: TranslateLoader) {
-        let loaderIndex = 0;
-        while (this.loaders.has(loaderIndex)) {
-            loaderIndex++;
+    public addLoader(loader: TranslateLoader): void {
+        const existingLoader = this.getLoaderRef(loader);
+        if (existingLoader) {
+            existingLoader.count++;
+        } else {
+            this.loaders.push({ loader, count: 1 });
         }
-        this.loaders.set(loaderIndex, loader);
-        return loaderIndex;
     }
 
-    removeLoader(loaderIndex: number) {
-        if (this.loaders.has(loaderIndex)) this.loaders.delete(loaderIndex);
+    public removeLoader(loader: TranslateLoader): void {
+        const existingLoader = this.getLoaderRef(loader);
+        if (existingLoader) {
+            existingLoader.count--;
+            if (existingLoader.count === 0) {
+                this.loaders = this.loaders.filter((ref) => ref.loader !== loader);
+            }
+        }
     }
 
-    getLoaders() {
-        return this.loaders;
+    private getLoaderRef(loader: TranslateLoader): LoaderReference | undefined {
+        return this.loaders.find((ref) => ref.loader === loader);
+    }
+
+    public getLoaders(): TranslateLoader[] {
+        return this.loaders.map((ref) => ref.loader);
     }
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
@@ -96,7 +107,6 @@ export class TranslateStore {
 
     public setCurrentLang(lang: string, emitChange = true): void {
         this.currentLang = lang;
-
         if (emitChange) {
             this._onLangChange.next({ lang: lang, translations: this.translations[lang] });
         }

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 import { TranslateLoader } from "./translate.loader";
 import {
@@ -35,12 +35,12 @@ export class TranslateStore {
      * Adds a new loader to the store
      * @returns the index of the newly added loader
      */
-    addLoader() {
+    addLoader(loader: TranslateLoader) {
         let loaderIndex = 0;
         while (this.loaders.has(loaderIndex)) {
             loaderIndex++;
         }
-        this.loaders.set(loaderIndex, inject(TranslateLoader));
+        this.loaders.set(loaderIndex, loader);
         return loaderIndex;
     }
 
@@ -50,10 +50,6 @@ export class TranslateStore {
 
     getLoaders() {
         return this.loaders;
-    }
-
-    getLoader(loaderIndex: number) {
-        return this.loaders.get(loaderIndex);
     }
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { inject, Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 import { TranslateLoader } from "./translate.loader";
 import {
@@ -30,6 +30,31 @@ export class TranslateStore {
     private languages: Language[] = [];
 
     loaders = new Map<number, TranslateLoader>();
+
+    /**
+     * Adds a new loader to the store
+     * @returns the index of the newly added loader
+     */
+    addLoader() {
+        let loaderIndex = 0;
+        while (this.loaders.has(loaderIndex)) {
+            loaderIndex++;
+        }
+        this.loaders.set(loaderIndex, inject(TranslateLoader));
+        return loaderIndex;
+    }
+
+    removeLoader(loaderIndex: number) {
+        if (this.loaders.has(loaderIndex)) this.loaders.delete(loaderIndex);
+    }
+
+    getLoaders() {
+        return this.loaders;
+    }
+
+    getLoader(loaderIndex: number) {
+        return this.loaders.get(loaderIndex);
+    }
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
         return this.translations[language];

--- a/projects/ngx-translate/src/tests/translate.compiler.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.compiler.spec.ts
@@ -9,10 +9,10 @@ import {
     TranslateService,
     Translation,
     TranslationObject,
-    provideTranslateService,
     provideTranslateLoader,
     provideTranslateCompiler,
 } from "../public-api";
+import { provideTestableTranslateService, TestableTranslateService } from "./test-helpers";
 
 const translations: TranslationObject = { LOAD: "This is a test" };
 
@@ -25,26 +25,27 @@ class FakeLoader implements TranslateLoader {
 }
 
 describe("TranslateCompiler", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
 
     describe("with default TranslateNoOpCompiler", () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 providers: [
-                    provideTranslateService(),
-                    provideTranslateLoader(FakeLoader),
-                    provideTranslateCompiler(TranslateNoOpCompiler),
+                    provideTestableTranslateService({
+                        loader: provideTranslateLoader(FakeLoader),
+                        compiler: provideTranslateCompiler(TranslateNoOpCompiler),
+                    }),
                 ],
             });
-            translate = TestBed.inject(TranslateService);
+            translate = TestBed.inject(TranslateService) as TestableTranslateService;
 
             translate.use("en");
         });
 
         it("should use the correct compiler", () => {
             expect(translate).toBeDefined();
-            expect(translate.compiler).toBeDefined();
-            expect(translate.compiler instanceof TranslateNoOpCompiler).toBeTruthy();
+            expect(translate.getCompiler()).toBeDefined();
+            expect(translate.getCompiler() instanceof TranslateNoOpCompiler).toBeTruthy();
         });
 
         it("should use the compiler on loading translations", () => {
@@ -89,20 +90,21 @@ describe("TranslateCompiler", () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 providers: [
-                    provideTranslateService({}),
-                    provideTranslateLoader(FakeLoader),
-                    provideTranslateCompiler(CustomCompiler),
+                    provideTestableTranslateService({
+                        loader: provideTranslateLoader(FakeLoader),
+                        compiler: provideTranslateCompiler(CustomCompiler),
+                    }),
                 ],
             });
-            translate = TestBed.inject(TranslateService);
+            translate = TestBed.inject(TranslateService) as TestableTranslateService;
 
             translate.use("en");
         });
 
         it("should use the correct compiler", () => {
             expect(translate).toBeDefined();
-            expect(translate.compiler).toBeDefined();
-            expect(translate.compiler instanceof CustomCompiler).toBeTruthy();
+            expect(translate.getCompiler()).toBeDefined();
+            expect(translate.getCompiler() instanceof CustomCompiler).toBeTruthy();
         });
 
         it("should use the compiler on loading translations", () => {

--- a/projects/ngx-translate/src/tests/translate.loader.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.loader.spec.ts
@@ -8,9 +8,9 @@ import {
     TranslateService,
     Translation,
     TranslationObject,
-    provideTranslateService,
     provideTranslateLoader,
 } from "../public-api";
+import { provideTestableTranslateService, TestableTranslateService } from "./test-helpers";
 
 const translations: TranslationObject = { TEST: "This is a test" };
 
@@ -22,17 +22,19 @@ class FakeLoader implements TranslateLoader {
 }
 
 describe("TranslateLoader", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
 
     it("should be able to provide TranslateStaticLoader", () => {
         TestBed.configureTestingModule({
-            providers: [provideTranslateService({}), provideTranslateLoader(FakeLoader)],
+            providers: [
+                provideTestableTranslateService({ loader: provideTranslateLoader(FakeLoader) }),
+            ],
         });
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
 
         expect(translate).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof FakeLoader).toBeTruthy();
+        expect(translate.getCurrentLoader()).toBeDefined();
+        expect(translate.getCurrentLoader() instanceof FakeLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use("en");
@@ -52,15 +54,14 @@ describe("TranslateLoader", () => {
 
         TestBed.configureTestingModule({
             providers: [
-                provideTranslateService({}),
-                { provide: TranslateLoader, useClass: CustomLoader },
+                provideTestableTranslateService({ loader: provideTranslateLoader(CustomLoader) }),
             ],
         });
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
 
         expect(translate).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof CustomLoader).toBeTruthy();
+        expect(translate.getCurrentLoader()).toBeDefined();
+        expect(translate.getCurrentLoader() instanceof CustomLoader).toBeTruthy();
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use("en");
@@ -73,13 +74,17 @@ describe("TranslateLoader", () => {
 
     it("TranslateNoOpLoader should return empty object", () => {
         TestBed.configureTestingModule({
-            providers: [provideTranslateService(), provideTranslateLoader(TranslateNoOpLoader)],
+            providers: [
+                provideTestableTranslateService({
+                    loader: provideTranslateLoader(TranslateNoOpLoader),
+                }),
+            ],
         });
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
 
         expect(translate).toBeDefined();
-        expect(translate.currentLoader).toBeDefined();
-        expect(translate.currentLoader instanceof TranslateNoOpLoader).toBeTruthy();
+        expect(translate.getCurrentLoader()).toBeDefined();
+        expect(translate.getCurrentLoader() instanceof TranslateNoOpLoader).toBeTruthy();
 
         translate.use("en").subscribe((res: InterpolatableTranslationObject) => {
             expect(res as object).toEqual({});

--- a/projects/ngx-translate/src/tests/translate.pipe.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.pipe.spec.ts
@@ -23,7 +23,9 @@ describe("TranslatePipe (unit)", () => {
 
         TestBed.configureTestingModule({
             providers: [
-                provideTranslateService(),
+                provideTranslateService({
+                    loader: provideTranslateLoader(DelayedFakeLoader),
+                }),
                 {
                     provide: ChangeDetectorRef,
                     useValue: ref,
@@ -32,7 +34,6 @@ describe("TranslatePipe (unit)", () => {
                     provide: TranslatePipe,
                     useClass: TranslatePipe,
                 },
-                provideTranslateLoader(DelayedFakeLoader),
             ],
         });
 

--- a/projects/ngx-translate/src/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.service.spec.ts
@@ -15,6 +15,7 @@ import {
     TranslationChangeEvent,
     TranslationObject,
 } from "../public-api";
+import { provideTestableTranslateService, TestableTranslateService } from "./test-helpers";
 
 let translations: TranslationObject = { TEST: "This is a test" };
 
@@ -37,7 +38,7 @@ export interface User {
 }
 
 describe("TranslateService (Delayed loading)", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
 
     class DelayedLoader implements TranslateLoader {
         getTranslation(lang: string): Observable<TranslationObject> {
@@ -55,9 +56,11 @@ describe("TranslateService (Delayed loading)", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            providers: [provideTranslateService({}), provideTranslateLoader(DelayedLoader)],
+            providers: [
+                provideTestableTranslateService({ loader: provideTranslateLoader(DelayedLoader) }),
+            ],
         });
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
     });
 
     it("currentLang should be the language, on which use() was called last - in order", fakeAsync(() => {
@@ -102,18 +105,17 @@ describe("TranslateService (Delayed loading)", () => {
 });
 
 describe("TranslateService", () => {
-    let translate: TranslateService;
+    let translate: TestableTranslateService;
 
     const fakeNavigator: FakeNavigator = window.navigator as unknown as FakeNavigator;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [
-                provideTranslateService({}),
-                { provide: TranslateLoader, useClass: FakeLoader },
+                provideTestableTranslateService({ loader: provideTranslateLoader(FakeLoader) }),
             ],
         });
-        translate = TestBed.inject(TranslateService);
+        translate = TestBed.inject(TranslateService) as TestableTranslateService;
     });
 
     afterEach(() => {
@@ -726,7 +728,7 @@ describe("TranslateService", () => {
 
     it("should not make duplicate getTranslation calls", fakeAsync(() => {
         let getTranslationCalls = 0;
-        spyOn(translate.currentLoader, "getTranslation").and.callFake(() => {
+        spyOn(translate.getCurrentLoader(), "getTranslation").and.callFake(() => {
             getTranslationCalls += 1;
             return timer(1000).pipe(map(() => translations));
         });
@@ -740,7 +742,7 @@ describe("TranslateService", () => {
 
     it("should subscribe to the loader just once", () => {
         let subscriptions = 0;
-        spyOn(translate.currentLoader, "getTranslation").and.callFake(() => {
+        spyOn(translate.getCurrentLoader(), "getTranslation").and.callFake(() => {
             return defer(() => {
                 subscriptions++;
                 return of(translations);
@@ -755,16 +757,16 @@ describe("TranslateService", () => {
     });
 
     it("should compile translations only once, even when subscribing to translations while translations are loading", fakeAsync(() => {
-        spyOn(translate.currentLoader, "getTranslation").and.callFake(() => {
+        spyOn(translate.getCurrentLoader(), "getTranslation").and.callFake(() => {
             return timer(1000).pipe(map(() => translations));
         });
 
         let translateCompilerCallCount = 0;
-        spyOn(translate.compiler, "compile").and.callFake((value) => {
+        spyOn(translate.getCompiler(), "compile").and.callFake((value) => {
             ++translateCompilerCallCount;
             return value;
         });
-        spyOn(translate.compiler, "compileTranslations").and.callFake((value) => {
+        spyOn(translate.getCompiler(), "compileTranslations").and.callFake((value) => {
             ++translateCompilerCallCount;
             return value;
         });


### PR DESCRIPTION
## Description
As we're now having multiple instance of the `TranslateService`, the only way to sync language across all services is through the `store`.

As [this issue](https://github.com/ngx-translate/core/issues/1585) describe, when adding a new loader, and changing the lang, the parent loader isn't triggered anymore. 

## Cause
The loading happen inside the service, but this service is not aware of the other loaders

## Proposed solution
Storing each `loader` inside the `store`, and calling it when needed. 

- New `loaders` map inside the `store` class
- On service instantiation, add the new loader into the `loaders` map
- On service destroy, remove this loader (language aren't updated as this does not seems required)
- On language change, triggering every loaders.

## Food for though
This PR is more "food for though" than a finite PR, as I'm aware following have not been solved
- Should we empty the translation on destroy? (I think we should not)
- Only the last compiler will be triggered, (we could also store compilers into a map and this would solve the error)
- This triggers one huge request, and we have to await it, maybe an other way could be optimized. 
 