### PR TITLE
fix: make private properties and methods protected in order to allow usage in extending classes

### DIFF
--- a/projects/ngx-translate/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/src/lib/translate.directive.ts
@@ -33,16 +33,16 @@ interface ExtendedNode extends Text {
     standalone: true,
 })
 export class TranslateDirective implements AfterViewChecked, OnDestroy {
-    private translateService: TranslateService = inject(TranslateService);
-    private element: ElementRef = inject(ElementRef);
-    private _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
+    protected translateService: TranslateService = inject(TranslateService);
+    protected element: ElementRef = inject(ElementRef);
+    protected _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
 
-    private key!: string;
-    private lastParams?: InterpolationParameters;
-    private currentParams?: InterpolationParameters;
-    private readonly onLangChangeSub!: Subscription;
-    private readonly onFallbackLangChangeSub!: Subscription;
-    private readonly onTranslationChangeSub!: Subscription;
+    protected key!: string;
+    protected lastParams?: InterpolationParameters;
+    protected currentParams?: InterpolationParameters;
+    protected readonly onLangChangeSub!: Subscription;
+    protected readonly onFallbackLangChangeSub!: Subscription;
+    protected readonly onTranslationChangeSub!: Subscription;
 
     @Input() set translate(key: string) {
         if (key) {

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -24,10 +24,10 @@ import { equals, isDefinedAndNotNull, isDict, isString } from "./util";
     pure: false, // required to update the value when the promise is resolved
 })
 export class TranslatePipe implements PipeTransform, OnDestroy {
-    private translate: TranslateService = inject(TranslateService);
-    private _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
+    protected translate: TranslateService = inject(TranslateService);
+    protected _ref: ChangeDetectorRef = inject(ChangeDetectorRef);
 
-    private value: StrictTranslation = "";
+    protected value: StrictTranslation = "";
     lastKey: string | null = null;
     lastParams: InterpolationParameters[] = [];
     onTranslationChange: Subscription | undefined;
@@ -140,7 +140,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
     /**
      * Clean any existing subscription to change events
      */
-    private _dispose(): void {
+    protected _dispose(): void {
         if (typeof this.onTranslationChange !== "undefined") {
             this.onTranslationChange.unsubscribe();
             this.onTranslationChange = undefined;

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -174,18 +174,18 @@ export abstract class ITranslateService {
 
 @Injectable()
 export class TranslateService implements ITranslateService {
-    private loadingTranslations!: Observable<InterpolatableTranslationObject>;
-    private pending = false;
-    private _translationRequests: Record<Language, Observable<TranslationObject>> = {};
-    private lastUseLanguage: Language | null = null;
+    protected loadingTranslations!: Observable<InterpolatableTranslationObject>;
+    protected pending = false;
+    protected _translationRequests: Record<Language, Observable<TranslationObject>> = {};
+    protected lastUseLanguage: Language | null = null;
 
     protected currentLoader = inject(TranslateLoader);
     protected compiler = inject(TranslateCompiler);
-    private parser = inject(TranslateParser);
-    private missingTranslationHandler = inject(MissingTranslationHandler);
-    private store: TranslateStore = inject(TranslateStore);
+    protected parser = inject(TranslateParser);
+    protected missingTranslationHandler = inject(MissingTranslationHandler);
+    protected store: TranslateStore = inject(TranslateStore);
 
-    private readonly extend: boolean = false;
+    protected readonly extend: boolean = false;
 
     /**
      * An Observable to listen to translation change events
@@ -308,7 +308,7 @@ export class TranslateService implements ITranslateService {
     /**
      * Retrieves the given translations
      */
-    private loadOrExtendLanguage(lang: Language): Observable<TranslationObject> | undefined {
+    protected loadOrExtendLanguage(lang: Language): Observable<TranslationObject> | undefined {
         // if this language is unavailable or extend is true, ask for it
         if (!this.store.hasTranslationFor(lang) || this.extend) {
             this._translationRequests[lang] =
@@ -322,7 +322,7 @@ export class TranslateService implements ITranslateService {
     /**
      * Changes the current lang
      */
-    private changeLang(lang: Language): void {
+    protected changeLang(lang: Language): void {
         if (lang !== this.lastUseLanguage) {
             // received new language data,
             // but this was not the one requested last
@@ -336,7 +336,7 @@ export class TranslateService implements ITranslateService {
         return this.store.getCurrentLang();
     }
 
-    private loadAndCompileTranslations(
+    protected loadAndCompileTranslations(
         lang: Language,
     ): Observable<InterpolatableTranslationObject> {
         this.pending = true;
@@ -390,7 +390,7 @@ export class TranslateService implements ITranslateService {
         this.store.addLanguages(languages);
     }
 
-    private getParsedResultForKey(
+    protected getParsedResultForKey(
         key: string,
         interpolateParams?: InterpolationParameters,
     ): StrictTranslation | Observable<StrictTranslation> {
@@ -416,11 +416,11 @@ export class TranslateService implements ITranslateService {
         return this.store.getFallbackLang();
     }
 
-    private getTextToInterpolate(key: string): InterpolatableTranslation | undefined {
+    protected getTextToInterpolate(key: string): InterpolatableTranslation | undefined {
         return this.store.getTranslation(key);
     }
 
-    private runInterpolation(
+    protected runInterpolation(
         translations: InterpolatableTranslation,
         interpolateParams?: InterpolationParameters,
     ): StrictTranslation {
@@ -439,7 +439,7 @@ export class TranslateService implements ITranslateService {
         return this.parser.interpolate(translations, interpolateParams);
     }
 
-    private runInterpolationOnArray(
+    protected runInterpolationOnArray(
         translations: InterpolatableTranslation,
         interpolateParams: InterpolationParameters | undefined,
     ) {
@@ -448,7 +448,7 @@ export class TranslateService implements ITranslateService {
         );
     }
 
-    private runInterpolationOnDict(
+    protected runInterpolationOnDict(
         translations: InterpolatableTranslationObject,
         interpolateParams: InterpolationParameters | undefined,
     ) {
@@ -474,7 +474,7 @@ export class TranslateService implements ITranslateService {
             : this.getParsedResultForKey(key, interpolateParams);
     }
 
-    private getParsedResultForArray(
+    protected getParsedResultForArray(
         key: string[],
         interpolateParams: InterpolationParameters | undefined,
     ) {

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -16,17 +16,17 @@ export type DeepReadonly<T> = {
 
 @Injectable()
 export class TranslateStore {
-    private _onTranslationChange: Subject<TranslationChangeEvent> =
+    protected _onTranslationChange: Subject<TranslationChangeEvent> =
         new Subject<TranslationChangeEvent>();
-    private _onLangChange: Subject<LangChangeEvent> = new Subject<LangChangeEvent>();
-    private _onFallbackLangChange: Subject<FallbackLangChangeEvent> =
+    protected _onLangChange: Subject<LangChangeEvent> = new Subject<LangChangeEvent>();
+    protected _onFallbackLangChange: Subject<FallbackLangChangeEvent> =
         new Subject<FallbackLangChangeEvent>();
 
-    private fallbackLang: Language | null = null;
-    private currentLang!: Language;
+    protected fallbackLang: Language | null = null;
+    protected currentLang!: Language;
 
-    private translations: Record<Language, InterpolatableTranslationObject> = {};
-    private languages: Language[] = [];
+    protected translations: Record<Language, InterpolatableTranslationObject> = {};
+    protected languages: Language[] = [];
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
         return this.translations[language];


### PR DESCRIPTION
We are extending some of these classes for our usecases. Some of the properties and methods were previously public and are not private. Making the protected would allow us to access them again in our extending classes..