### PR TITLE
fix: feature array length on interpolation

### DIFF
--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -154,7 +154,7 @@ export function getValue(target: unknown, key: string): unknown {
             }
 
             if (isArray(target)) {
-                const index = parseInt(key, 10);
+                const index = key === "length" ? key : parseInt(key, 10);
                 if (
                     isDefined(target[index]) &&
                     (isDict(target[index]) || isArray(target[index]) || isLastKey)

--- a/projects/ngx-translate/src/tests/utils.spec.ts
+++ b/projects/ngx-translate/src/tests/utils.spec.ts
@@ -228,6 +228,15 @@ describe("Utils", () => {
 
             expect(getValue("test", "key")).not.toBeDefined();
         });
+
+        it("should provide an array's length", () => {
+            expect(getValue({items: ["A", "B", "C"]}, "items.length")).toEqual(3);
+
+            expect(getValue({items: "foo"}, "items.length")).toBeUndefined();
+            expect(getValue({items: null}, "items.length")).toBeUndefined();
+            expect(getValue({items: true}, "items.length")).toBeUndefined();
+            expect(getValue({items: {length: "foo"}}, "items.length")).toEqual("foo");
+        });
     });
 
     describe("isDict()", () => {

--- a/projects/ngx-translate/src/tests/utils.spec.ts
+++ b/projects/ngx-translate/src/tests/utils.spec.ts
@@ -232,6 +232,11 @@ describe("Utils", () => {
         it("should provide an array's length", () => {
             expect(getValue({items: ["A", "B", "C"]}, "items.length")).toEqual(3);
 
+            expect(getValue({items: ["A", ["B", "b"], "C"]}, "items.length")).toEqual(3);
+            expect(getValue({items: ["A", ["B", "b"], "C"]}, "items.1.length")).toEqual(2);
+            expect(getValue({items: ["A", ["B", "b"], "C"]}, "items.length.1")).toBeUndefined();
+            expect(getValue({items: ["A", ["B", "b"], "C"]}, "items.length.length")).toBeUndefined();
+
             expect(getValue({items: "foo"}, "items.length")).toBeUndefined();
             expect(getValue({items: null}, "items.length")).toBeUndefined();
             expect(getValue({items: true}, "items.length")).toBeUndefined();


### PR DESCRIPTION
On interpolating arrays, using `length` results in the array's length as this has not been working anymore before since v17.