### PR TITLE
feat: $languages

### DIFF
--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -1,11 +1,11 @@
 import {
-    computed,
-    inject,
-    Injectable,
-    InjectionToken,
-    isSignal,
-    Signal,
-    signal,
+  computed,
+  inject,
+  Injectable,
+  InjectionToken,
+  isSignal,
+  Signal,
+  signal,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { concat, defer, EMPTY, finalize, forkJoin, isObservable, merge, Observable, of, Subject, tap } from "rxjs";
@@ -14,22 +14,22 @@ import { DefaultMissingTranslationHandler, MissingTranslationHandler } from "./m
 import { TranslateCompiler } from "./translate.compiler";
 import { TranslateLoader } from "./translate.loader";
 import { TranslateParser } from "./translate.parser";
+import {
+  DefaultLangChangeEvent,
+  FallbackLangChangeEvent,
+  InterpolatableTranslation,
+  InterpolatableTranslationObject,
+  InterpolationParameters,
+  ITranslateService,
+  LangChangeEvent,
+  Language,
+  StrictTranslation,
+  Translation,
+  TranslationChangeEvent,
+  TranslationObject,
+} from "./translate.service.interface";
 import { DeepReadonly, TranslateStore } from "./translate.store";
 import { insertValue, isArray, isDefinedAndNotNull, isDict, isString } from "./util";
-import {
-    DefaultLangChangeEvent,
-    FallbackLangChangeEvent,
-    InterpolatableTranslation,
-    InterpolatableTranslationObject,
-    InterpolationParameters,
-    ITranslateService,
-    LangChangeEvent,
-    Language,
-    StrictTranslation,
-    Translation,
-    TranslationChangeEvent,
-    TranslationObject,
-} from "./translate.service.interface";
 
 /**
  * Configuration object for the translation service.
@@ -81,6 +81,8 @@ export class TranslateService implements ITranslateService {
     protected _onFallbackLangChange = new Subject<FallbackLangChangeEvent>();
     protected _currentLang!: Language;
     protected _fallbackLang: Language | null = null;
+
+    $languages = this.store.$languages.asReadonly();
 
     protected getRoot(): TranslateService {
         return this.parent ? this.parent.getRoot() : this;

--- a/projects/ngx-translate/src/lib/translate.store.ts
+++ b/projects/ngx-translate/src/lib/translate.store.ts
@@ -1,12 +1,12 @@
-import { Injectable } from "@angular/core";
+import { Injectable, signal } from "@angular/core";
 import { Observable, Subject } from "rxjs";
-import { getValue, mergeDeep } from "./util";
 import {
     InterpolatableTranslation,
     InterpolatableTranslationObject,
     Language,
     TranslationChangeEvent,
 } from "./translate.service.interface";
+import { getValue, mergeDeep } from "./util";
 
 export type DeepReadonly<T> = {
     readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
@@ -18,7 +18,8 @@ export class TranslateStore {
         new Subject<TranslationChangeEvent>();
 
     protected translations: Record<Language, InterpolatableTranslationObject> = {};
-    protected languages: Language[] = [];
+
+    $languages = signal<Language[]>([]);
 
     public getTranslations(language: Language): DeepReadonly<InterpolatableTranslationObject> {
         return this.translations[language];
@@ -41,7 +42,7 @@ export class TranslateStore {
     }
 
     public getLanguages(): readonly Language[] {
-        return this.languages;
+        return this.$languages();
     }
 
     get onTranslationChange(): Observable<TranslationChangeEvent> {
@@ -49,7 +50,7 @@ export class TranslateStore {
     }
 
     public addLanguages(languages: Language[]): void {
-        this.languages = Array.from(new Set([...this.languages, ...languages]));
+        this.$languages.set(Array.from(new Set([...this.$languages(), ...languages])));
     }
 
     public hasTranslationFor(lang: string) {

--- a/projects/test-app/src/app/components/language-switch/language-switch.component.ts
+++ b/projects/test-app/src/app/components/language-switch/language-switch.component.ts
@@ -1,10 +1,11 @@
-import { Component, inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 
 @Component({
     selector: "app-language-switch",
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
-        @for (lang of translate.getLangs(); track lang) {
+        @for (lang of translate.$languages(); track lang) {
             <button
                 (click)="translate.use(lang)"
                 [class.active]="translate.getCurrentLang() === lang"


### PR DESCRIPTION
## Description
- Add the $languages signal.
- Refactor the language-switch example to not use function directly inside HTML template

## Why?
Using function directly in html should be avoided.  
So, for an optimized implementation, a user should subscribe to the languages change, and update a signal himself for the change to be visible. 

`$languages` aime to reduce this complexity

## Side Note
I couldn't run `pnpm format` as it changes a few places inside the codebase.  