### PR TITLE
fix(providers): detect minified nameless classes in isClass (#1622)

### DIFF
--- a/projects/ngx-translate/src/lib/translate.providers.ts
+++ b/projects/ngx-translate/src/lib/translate.providers.ts
@@ -40,7 +40,11 @@ export interface RootTranslateServiceConfig extends ChildTranslateServiceConfig 
 }
 
 function isClass<T>(fn: Type<T> | (() => T)): fn is Type<T> {
-    return /^class\s/.test(Function.prototype.toString.call(fn));
+    // Match both source forms: `class Foo {` (named/unminified, whitespace after
+    // the keyword) and `class{` (anonymous, emitted by minifiers with no space).
+    // Missing the `class{` form mis-detects a minified class as a factory, so DI
+    // calls it without `new` and the app crashes. See ngx-translate/core#1622.
+    return /^class[{\s]/.test(Function.prototype.toString.call(fn));
 }
 
 function toProvider<T>(

--- a/projects/ngx-translate/src/tests/translate.providers.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.providers.spec.ts
@@ -1,4 +1,4 @@
-import { FactoryProvider, InjectionToken, inject } from "@angular/core";
+import { ClassProvider, FactoryProvider, InjectionToken, Type, inject } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import {
     provideTranslateService,
@@ -445,6 +445,20 @@ describe("Translate Providers", () => {
             spyOn(console, "warn");
             const providers = provideTranslateService({ loader: BareLoader });
             expect(providers[0]).toEqual({ provide: TranslateLoader, useClass: BareLoader });
+        });
+
+        it("wraps a nameless (minified) class as useClass, not useFactory (#1622)", () => {
+            // Minifiers emit anonymous class expressions as `class{…}` with no
+            // whitespace after the keyword. A class literal written here would be
+            // re-indented to `class … {` by Prettier and wouldn't reproduce the
+            // bug, so eval is used to preserve the exact minified source that
+            // Function.prototype.toString reports back.
+            const NamelessLoader = eval(
+                "(class{getTranslation(){return of({})}})",
+            ) as Type<TranslateLoader>;
+            const provider = provideTranslateLoader(NamelessLoader);
+            expect((provider as ClassProvider).useClass).toBe(NamelessLoader);
+            expect("useFactory" in provider).toBe(false);
         });
 
         it("auto-wraps a bare compiler class to the TranslateCompiler token", () => {


### PR DESCRIPTION
## Summary

Fixes #1622. When a build minifies plugin classes, anonymous class expressions are emitted as `class{…}` with **no whitespace** after the `class` keyword (e.g. `Oe=class{getTranslation(l){…}}`). The `isClass` guard in `translate.providers.ts` tested `/^class\s/`, which requires whitespace, so a minified class was mis-detected as a factory function. `toProvider` then registered it with `useFactory`, and Angular DI called it **without `new`** — crashing the app at bootstrap with:

> `TypeError: Class constructor Oe cannot be invoked without 'new'`

This only surfaced in production builds with `optimize.scripts: true`; unminified dev builds keep the class name and the space, so `^class\s` matched.

## Fix

Broaden the detection to also accept `{` directly after the keyword:

```diff
- return /^class\s/.test(Function.prototype.toString.call(fn));
+ return /^class[{\s]/.test(Function.prototype.toString.call(fn));
```

After the `class` keyword valid JS only ever has whitespace (named, or anonymous-with-space) or `{` directly (anonymous minified), so `[{\s]` covers every real form. No false positives: a function named `classify` stringifies to `function classify(`/`classify(`, and arrow factories to `(`/`()=>` — both correctly stay `useFactory`.

## Test plan

- [x] New regression test in `translate.providers.spec.ts` reproduces minified output via `eval("(class{…})")` (a class literal written in source gets a space inserted by Prettier and wouldn't reproduce the bug) and asserts it resolves to `useClass`, not `useFactory`.
- [x] Verified the test genuinely guards the fix: old regex returns `false` against `class{…}`, new regex returns `true`.
- [x] Full suite green: 425 ngx-translate + 28 http-loader specs, 0 failures.
- [x] ESLint + Prettier clean (no `eslint-disable` needed — `no-eval` isn't enabled in this config).