### PR TITLE
chore: add Dependabot config for grouped weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+    # npm workspace (pnpm-lock.yaml at root). The published packages bundle no
+    # runtime deps, so everything here is dev/build/test toolchain. Group it to
+    # avoid PR spam. Major bumps stay ungrouped so Angular majors land as
+    # deliberate, reviewable upgrades.
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 5
+      commit-message:
+          prefix: chore
+          include: scope
+      groups:
+          angular:
+              patterns:
+                  - "@angular*"
+                  - "@angular-devkit/*"
+                  - "ng-packagr"
+              update-types:
+                  - minor
+                  - patch
+          dev-dependencies:
+              patterns:
+                  - "*"
+              exclude-patterns:
+                  - "@angular*"
+                  - "@angular-devkit/*"
+                  - "ng-packagr"
+              update-types:
+                  - minor
+                  - patch
+
+    - package-ecosystem: github-actions
+      directory: "/"
+      schedule:
+          interval: weekly
+          day: monday
+      commit-message:
+          prefix: ci
+      groups:
+          github-actions:
+              patterns:
+                  - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable automated dependency-update PRs.

## Why

The repo has Dependabot security **alerts** on (GitHub default) but no config, so there were no update PRs. 23 alerts had accumulated with no automated remediation path.

Context on exposure: the published packages (`@ngx-translate/core`, `@ngx-translate/http-loader`) bundle **zero runtime dependencies** (only peerDeps). All open alerts are in the dev/build/test toolchain (lockfile + compat fixtures) and do not reach downstream consumers. This config is about toolchain hygiene and stopping the alert pileup, not a shipped CVE.

## Config

- **npm** ecosystem at `/` (covers the pnpm workspace lockfile), weekly (Monday), max 5 open PRs.
  - `angular` group: `@angular*`, `@angular-devkit/*`, `ng-packagr` (minor/patch only).
  - `dev-dependencies` group: everything else (minor/patch only).
  - Majors stay ungrouped so Angular major upgrades land as deliberate, reviewable PRs.
- **github-actions** ecosystem at `/`, weekly, grouped.
- Conventional `commit-message` prefixes (`chore` / `ci`) to satisfy commitlint.