### PR TITLE
feat: typed translation keys via augmentable registry and DeepKeys

### DIFF
--- a/.github/workflows/ngx-translate-test.yml
+++ b/.github/workflows/ngx-translate-test.yml
@@ -31,6 +31,8 @@ jobs:
             - run: pnpm run lint
             - run: pnpm run build-all
             - run: pnpm run test-ci
+            - run: pnpm run test-types
+            - run: pnpm run test-templates
 
     compat:
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
         "watch": "ng build --watch --configuration development",
         "test": "ng test ngx-translate --code-coverage",
         "test-ci": "ng test ngx-translate --watch=false --browsers=ChromeHeadless && ng test http-loader --watch=false --browsers=ChromeHeadless",
+        "test-types": "tsc -p projects/ngx-translate/type-tests/tsconfig.json",
+        "test-templates": "node projects/ngx-translate/template-tests/run.mjs",
         "coverage": "ng test ngx-translate --code-coverage --watch=false --browsers=ChromeHeadless",
         "lint": "ng lint",
         "format": "prettier --write .",

--- a/projects/ngx-translate/src/lib/missing-translation-handler.ts
+++ b/projects/ngx-translate/src/lib/missing-translation-handler.ts
@@ -11,8 +11,13 @@ export interface MissingTranslationHandlerParams {
 
     /**
      * an instance of the service that was unable to translate the key.
+     *
+     * Pinned to the unconstrained `string` key-space (not the augmentable
+     * `TranslateService` default, which narrows to the app's key union): a
+     * handler fires *because* a key was missing, so it must stay key-agnostic
+     * and work regardless of which typed key-space the originating service uses.
      */
-    translateService: TranslateService;
+    translateService: TranslateService<string>;
 
     /**
      * interpolation params that were passed along for translating the given key.

--- a/projects/ngx-translate/src/lib/translate-block.directive.ts
+++ b/projects/ngx-translate/src/lib/translate-block.directive.ts
@@ -1,9 +1,20 @@
 import { Directive, inject, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
 import { TranslateService } from "./translate.service";
-import { InterpolationParameters, Translation } from "./translate.service.interface";
+import {
+    InterpolationParameters,
+    Translation,
+    TranslationKey,
+} from "./translate.service.interface";
 
 export class TranslateBlockContext {
-    constructor(public $implicit: (key: string, params?: InterpolationParameters) => Translation) {}
+    // `$implicit` is the `t` bound via `*translateBlock="let t"`. Typing its key
+    // parameter to TranslationKey is what makes `{{ t('key') }}` key-checked
+    // under strictTemplates (Angular reads this context type via the
+    // ngTemplateContextGuard below), matching the registry-default typing the
+    // `| translate` pipe and `[translate]` directive get.
+    constructor(
+        public $implicit: (key: TranslationKey, params?: InterpolationParameters) => Translation,
+    ) {}
 }
 
 @Directive({
@@ -17,7 +28,10 @@ export class TranslateBlockDirective implements OnInit {
     private translateService = inject(TranslateService);
 
     ngOnInit(): void {
-        const translateFn = (key: string, params?: InterpolationParameters): Translation => {
+        const translateFn = (
+            key: TranslationKey,
+            params?: InterpolationParameters,
+        ): Translation => {
             // instant() internally reads the store's translations() signal, which establishes
             // Angular signal tracking during template evaluation — no explicit subscription needed.
             return this.translateService.instant(key, params);

--- a/projects/ngx-translate/src/lib/translate-content-key.ts
+++ b/projects/ngx-translate/src/lib/translate-content-key.ts
@@ -22,7 +22,11 @@ export class ContentKeyHandler {
     constructor(
         private element: ElementRef,
         private changeDetectorRef: ChangeDetectorRef,
-        private translateService: TranslateService,
+        // Pinned to the unconstrained `string` key-space (not the augmentable
+        // `TranslateService` default, which narrows to the app's key union):
+        // the content-as-key path scrapes arbitrary DOM text and calls
+        // `instant()` with it, so the keys cannot be constrained to a union.
+        private translateService: TranslateService<string>,
     ) {
         // Pass the offending element as a second `console.warn` arg so DevTools
         // can highlight it. Warn per element rather than once-per-page because

--- a/projects/ngx-translate/src/lib/translate.directive.ts
+++ b/projects/ngx-translate/src/lib/translate.directive.ts
@@ -18,6 +18,7 @@ import { equals, isDefinedAndNotNull, isString } from "./util";
 import {
     InterpolationParameters,
     Translation,
+    TranslationKey,
     TranslationObject,
 } from "./translate.service.interface";
 import { ContentKeyHandler } from "./translate-content-key";
@@ -34,11 +35,11 @@ export class TranslateDirective implements AfterViewChecked {
     private changeDetectorRef = inject(ChangeDetectorRef);
     private injector = inject(Injector);
 
-    private key!: string;
+    private key!: TranslationKey;
     private currentParams?: InterpolationParameters;
 
     // Signal-based explicit key path
-    private keySignal: WritableSignal<string> | null = null;
+    private keySignal: WritableSignal<TranslationKey> | null = null;
     private paramsSignal: WritableSignal<InterpolationParameters | undefined> | null = null;
     private translationSignal: Signal<Translation | TranslationObject> | null = null;
     private effectCreated = false;
@@ -46,7 +47,7 @@ export class TranslateDirective implements AfterViewChecked {
     // Deprecated content-as-key path
     private contentKeyHandler: ContentKeyHandler | null = null;
 
-    @Input() set translate(key: string) {
+    @Input() set translate(key: TranslationKey) {
         if (key) {
             this.key = key;
 

--- a/projects/ngx-translate/src/lib/translate.function.ts
+++ b/projects/ngx-translate/src/lib/translate.function.ts
@@ -4,6 +4,7 @@ import {
     InterpolationParameters,
     Language,
     Translation,
+    TranslationKey,
     TranslationObject,
 } from "./translate.service.interface";
 
@@ -21,11 +22,43 @@ import {
  * @example
  * model = signal({ currentKey: 'HELLO' });
  * greeting = translate(() => this.model().currentKey);
+ *
+ * When you augment {@link NgxTranslateConfig}, the key source must itself be
+ * typed to the key-space: a dynamic key whose type widens to `string` (e.g.
+ * `currentKey: string`) will not satisfy the augmented union. Type it as
+ * {@link TranslationKey} (or the relevant subset) so the closure compiles.
+ *
+ * `Key` is wrapped in `NoInfer` so it is *not* inferred from the argument:
+ * without it, `translate("anything")` would infer `Key` as that literal and
+ * the `= TranslationKey` default (the augmented key-space) would never apply,
+ * silently disabling key checking. With `NoInfer`, the default governs — keys
+ * are checked against the registry — while an explicit `translate<OtherKeys>(…)`
+ * still scopes a call site to a different key-space.
  */
-export function translate(
-    key: string | string[] | (() => string | string[]),
+export function translate<Key extends string = TranslationKey>(
+    key: NoInfer<Key> | NoInfer<Key>[] | (() => NoInfer<Key> | NoInfer<Key>[]),
     params?: InterpolationParameters | (() => InterpolationParameters | undefined),
     lang?: Language | (() => Language | undefined),
 ): Signal<Translation | TranslationObject> {
-    return inject(TranslateService).translate(key, params, lang);
+    return inject<TranslateService<Key>>(TranslateService<Key>).translate(key, params, lang);
+}
+
+/**
+ * Injects the {@link TranslateService}, typed to the application's key-space.
+ *
+ * Prefer this over a bare `inject(TranslateService)` when you augment
+ * {@link NgxTranslateConfig}: TypeScript widens the key type to `any` when a
+ * generic class is used directly as an injection token, so a bare inject loses
+ * key checking. This helper pins it back:
+ *
+ * ```ts
+ * private translate = injectTranslateService(); // keys checked against the registry
+ * ```
+ *
+ * Pass an explicit type argument to scope a call site to a different key-space.
+ */
+export function injectTranslateService<
+    Key extends string = TranslationKey,
+>(): TranslateService<Key> {
+    return inject<TranslateService<Key>>(TranslateService<Key>);
 }

--- a/projects/ngx-translate/src/lib/translate.pipe.ts
+++ b/projects/ngx-translate/src/lib/translate.pipe.ts
@@ -1,7 +1,11 @@
 import { inject, Injectable, Pipe, PipeTransform, Signal } from "@angular/core";
 import { TranslateService } from "./translate.service";
 import { equals, isDefinedAndNotNull, isDict, isString } from "./util";
-import { InterpolationParameters, Translation } from "./translate.service.interface";
+import {
+    InterpolationParameters,
+    Translation,
+    TranslationKey,
+} from "./translate.service.interface";
 
 @Injectable()
 @Pipe({
@@ -9,15 +13,15 @@ import { InterpolationParameters, Translation } from "./translate.service.interf
     standalone: true,
     pure: false, // required to update the value when the signal changes
 })
-export class TranslatePipe implements PipeTransform {
-    private translateService = inject(TranslateService);
+export class TranslatePipe<Key extends string = TranslationKey> implements PipeTransform {
+    private translateService = inject<TranslateService<Key>>(TranslateService<Key>);
 
     private cachedSignal: Signal<Translation> | null = null;
     private lastKey: string | null = null;
     private lastParams: InterpolationParameters | undefined;
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    transform(query: string | undefined | null, ...args: any[]): any {
+    transform(query: Key | undefined | null, ...args: any[]): any {
         if (!query || !query.length) {
             return query;
         }

--- a/projects/ngx-translate/src/lib/translate.service.interface.ts
+++ b/projects/ngx-translate/src/lib/translate.service.interface.ts
@@ -2,6 +2,75 @@ import { InterpolateFunction } from "./translate.parser";
 import { Signal } from "@angular/core";
 import { Observable } from "rxjs";
 
+/**
+ * Augmentable registry for the application's translation key-space.
+ *
+ * The library ships this interface empty, so {@link TranslationKey} falls back
+ * to `string` and every key-accepting API stays unconstrained — fully
+ * backward-compatible with existing apps.
+ *
+ * Augment it once in your app to switch the whole library — `TranslateService`,
+ * `TranslatePipe` and the `[translate]` directive, in code *and* in templates —
+ * to a typed key-space:
+ *
+ * ```ts
+ * import en from "./assets/i18n/en.json";
+ *
+ * declare module "@ngx-translate/core" {
+ *   interface NgxTranslateConfig {
+ *     keys: DeepKeys<typeof en>;
+ *   }
+ * }
+ * ```
+ *
+ * The interface must stay empty here: declaration merging requires the consumer
+ * to *add* the `keys` member, which an optional or pre-typed member would
+ * forbid. This mirrors the `CustomTypeOptions` pattern from i18next.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- must stay empty so consumers can declaration-merge a `keys` member
+export interface NgxTranslateConfig {}
+
+/**
+ * The application's translation key type, resolved from {@link NgxTranslateConfig}.
+ *
+ * Resolves to the augmented `keys` union when an app registers one, and to
+ * `string` otherwise. Used as the default type argument for {@link ITranslateService}
+ * (and the concrete `TranslateService`, `TranslatePipe` and `[translate]`
+ * directive), so augmenting the registry retypes all of them at once.
+ */
+export type TranslationKey = NgxTranslateConfig extends { keys: infer Key extends string }
+    ? Key
+    : string;
+
+/**
+ * Derives the dotted leaf-path union from the shape of a statically-imported
+ * translation object: `{ a: "A", b: { c: "C" } }` yields `"a" | "b.c"`.
+ *
+ * Intended for {@link NgxTranslateConfig} augmentation. Only leaf paths — the
+ * actual translatable values — are produced; intermediate objects are not
+ * themselves keys. A leaf is anything that isn't a plain object: strings,
+ * numbers/booleans, and **arrays** (ngx-translate supports array translation
+ * values, which are translated under the array's own key, not by index). Only
+ * plain objects are recursed into. `NonNullable` strips `undefined` from
+ * optional members so they survive as leaf keys.
+ *
+ * Practical limits (the documented size envelope, verified by the
+ * big-dictionary type-test): the recursion handles deeply nested shapes up to
+ * TypeScript's instantiation-depth ceiling. Real i18n files are far shallower;
+ * pathologically deep dictionaries may hit `tsc`'s recursion limit.
+ */
+export type DeepKeys<Translations> = Translations extends string
+    ? never
+    : {
+          [Key in keyof Translations & string]: NonNullable<Translations[Key]> extends string
+              ? Key
+              : NonNullable<Translations[Key]> extends readonly unknown[]
+                ? Key
+                : NonNullable<Translations[Key]> extends object
+                  ? `${Key}.${DeepKeys<NonNullable<Translations[Key]>>}`
+                  : Key;
+      }[keyof Translations & string];
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type InterpolationParameters = Record<string, any>;
 export type StrictTranslation = string | StrictTranslation[] | TranslationObject | undefined | null;
@@ -41,7 +110,7 @@ export interface FallbackLangChangeEvent {
     translations: InterpolatableTranslationObject;
 }
 
-export abstract class ITranslateService {
+export abstract class ITranslateService<Key extends string = TranslationKey> {
     public abstract readonly onTranslationChange: Observable<TranslationChangeEvent>;
     public abstract readonly onLangChange: Observable<LangChangeEvent>;
     public abstract readonly onFallbackLangChange: Observable<FallbackLangChangeEvent>;
@@ -64,7 +133,7 @@ export abstract class ITranslateService {
     public abstract resetLang(lang: Language): void;
 
     public abstract instant(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Translation;
@@ -83,31 +152,27 @@ export abstract class ITranslateService {
      * @returns A Signal that emits the translated value
      */
     public abstract translate(
-        key: string | string[] | (() => string | string[]),
+        key: Key | Key[] | (() => Key | Key[]),
         params?: InterpolationParameters | (() => InterpolationParameters | undefined),
         lang?: Language | (() => Language | undefined),
     ): Signal<Translation | TranslationObject>;
 
     public abstract stream(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation>;
 
     public abstract getStreamOnTranslationChange(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation>;
 
-    public abstract set(
-        key: string,
-        translation: string | TranslationObject,
-        lang?: Language,
-    ): void;
+    public abstract set(key: Key, translation: string | TranslationObject, lang?: Language): void;
 
     public abstract get(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation>;
@@ -125,7 +190,7 @@ export abstract class ITranslateService {
     ): void;
 
     public abstract getParsedResult(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): StrictTranslation | Observable<StrictTranslation>;
@@ -180,7 +245,7 @@ export abstract class ITranslateService {
      * A `null` return means the service is the terminus of its translation
      * fallback chain — equivalent to "is this a root?".
      */
-    public abstract getParent(): ITranslateService | null;
+    public abstract getParent(): ITranslateService<Key> | null;
 
     /**
      * Returns the root of this service's hierarchy — the topmost service in
@@ -189,5 +254,5 @@ export abstract class ITranslateService {
      *
      * A root service returns itself.
      */
-    public abstract getRoot(): ITranslateService;
+    public abstract getRoot(): ITranslateService<Key>;
 }

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -42,6 +42,7 @@ import {
     StrictTranslation,
     Translation,
     TranslationChangeEvent,
+    TranslationKey,
     TranslationObject,
 } from "./translate.service.interface";
 
@@ -77,7 +78,9 @@ const makeObservable = <T>(value: T | Observable<T>): Observable<T> => {
 };
 
 @Injectable()
-export class TranslateService implements ITranslateService {
+export class TranslateService<Key extends string = TranslationKey>
+    implements ITranslateService<Key>
+{
     protected readonly loadingTranslations = new LoadingTranslationsRegistry();
     protected lastUseLanguage: Language | null = null;
 
@@ -88,7 +91,7 @@ export class TranslateService implements ITranslateService {
     protected store: TranslateStore = inject(TranslateStore);
     private readonly destroyRef = inject(DestroyRef);
 
-    protected readonly parent: TranslateService | null;
+    protected readonly parent: TranslateService<Key> | null;
 
     protected get isRoot(): boolean {
         return this.parent === null;
@@ -124,9 +127,9 @@ export class TranslateService implements ITranslateService {
      * A root service returns itself. Equivalent to walking `getParent()` until
      * it returns `null`, but provided as a convenience.
      */
-    public getRoot(): TranslateService {
+    public getRoot(): TranslateService<Key> {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
-        let svc: TranslateService = this;
+        let svc: TranslateService<Key> = this;
         while (svc.parent) svc = svc.parent;
         return svc;
     }
@@ -138,7 +141,7 @@ export class TranslateService implements ITranslateService {
      * A `null` return means the service is the terminus of its translation
      * fallback chain — equivalent to "is this a root?".
      */
-    public getParent(): TranslateService | null {
+    public getParent(): TranslateService<Key> | null {
         return this.parent;
     }
 
@@ -155,7 +158,7 @@ export class TranslateService implements ITranslateService {
 
     protected hasTranslationInChain(lang: Language): boolean {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
-        for (let svc: TranslateService | null = this; svc; svc = svc.parent) {
+        for (let svc: TranslateService<Key> | null = this; svc; svc = svc.parent) {
             if (svc.store.hasTranslationFor(lang)) return true;
         }
         return false;
@@ -164,7 +167,7 @@ export class TranslateService implements ITranslateService {
     protected chainTranslationChange$(): Observable<TranslationChangeEvent> {
         const streams: Observable<TranslationChangeEvent>[] = [];
         // eslint-disable-next-line @typescript-eslint/no-this-alias
-        for (let svc: TranslateService | null = this; svc; svc = svc.parent) {
+        for (let svc: TranslateService<Key> | null = this; svc; svc = svc.parent) {
             streams.push(svc.store.translationChange$);
         }
         return streams.length === 1 ? streams[0] : merge(...streams);
@@ -703,7 +706,7 @@ export class TranslateService implements ITranslateService {
      * Returns the parsed result of the translations
      */
     public getParsedResult(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): StrictTranslation | Observable<StrictTranslation> {
@@ -713,7 +716,7 @@ export class TranslateService implements ITranslateService {
     }
 
     protected getParsedResultForArray(
-        key: string[],
+        key: Key[],
         interpolateParams: InterpolationParameters | undefined,
         lang?: Language,
     ) {
@@ -746,7 +749,7 @@ export class TranslateService implements ITranslateService {
      * @returns the translated key, or an object of translated keys
      */
     public get(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation> {
@@ -778,7 +781,7 @@ export class TranslateService implements ITranslateService {
      * @returns A stream of the translated key, or an object of translated keys
      */
     public getStreamOnTranslationChange(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation> {
@@ -811,7 +814,7 @@ export class TranslateService implements ITranslateService {
      * @returns A stream of the translated key, or an object of translated keys
      */
     public stream(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Observable<Translation> {
@@ -846,7 +849,7 @@ export class TranslateService implements ITranslateService {
      * bypassing the current language and fallback chain.
      */
     public instant(
-        key: string | string[],
+        key: Key | Key[],
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): Translation {
@@ -914,7 +917,7 @@ export class TranslateService implements ITranslateService {
      * labels = this.translate.translate(['SAVE', 'CANCEL']);
      */
     public translate(
-        key: string | string[] | (() => string | string[]),
+        key: Key | Key[] | (() => Key | Key[]),
         params?: InterpolationParameters | (() => InterpolationParameters | undefined),
         lang?: Language | (() => Language | undefined),
     ): Signal<Translation | TranslationObject> {
@@ -927,7 +930,7 @@ export class TranslateService implements ITranslateService {
         });
     }
 
-    protected keyToObject(key: string | string[]) {
+    protected keyToObject(key: Key | Key[]) {
         if (Array.isArray(key)) {
             return key.reduce((acc: Record<string, string>, currKey: string) => {
                 acc[currKey] = currKey;
@@ -941,7 +944,7 @@ export class TranslateService implements ITranslateService {
      * Sets the translated value of a key, after compiling it
      */
     public set(
-        key: string,
+        key: Key,
         translation: string | TranslationObject,
         lang: Language = this.getCurrentLang()!,
     ): void {

--- a/projects/ngx-translate/src/public-api.ts
+++ b/projects/ngx-translate/src/public-api.ts
@@ -1,5 +1,5 @@
 export * from "./lib/extraction-marker";
-export { translate } from "./lib/translate.function";
+export { translate, injectTranslateService } from "./lib/translate.function";
 export * from "./lib/translate-block.directive";
 export * from "./lib/missing-translation-handler";
 export * from "./lib/translate.compiler";
@@ -35,3 +35,6 @@ export type { TranslationObject } from "./lib/translate.service.interface";
 export type { Translation } from "./lib/translate.service.interface";
 export type { StrictTranslation } from "./lib/translate.service.interface";
 export type { InterpolationParameters } from "./lib/translate.service.interface";
+export type { NgxTranslateConfig } from "./lib/translate.service.interface";
+export type { TranslationKey } from "./lib/translate.service.interface";
+export type { DeepKeys } from "./lib/translate.service.interface";

--- a/projects/ngx-translate/src/tests/translate.type-safety.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.type-safety.spec.ts
@@ -1,0 +1,162 @@
+import { TestBed } from "@angular/core/testing";
+import {
+    DeepKeys,
+    provideTranslateLoader,
+    TranslatePipe,
+    TranslateService,
+    TranslationObject,
+} from "../public-api";
+import { FakeLoader, provideTestableTranslateService } from "./test-helpers";
+
+/**
+ * Compile-time type-equality assertion. `Equal<A, B>` is `true` only when `A`
+ * and `B` are mutually assignable, so a wrong `DeepKeys` result fails the build.
+ */
+type Equal<A, B> =
+    (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+const translations: TranslationObject = { a: "A", b: { a: "BA", b: "BB" }, c: "C" };
+type MyKeys = "a" | "b.a" | "b.b" | "c";
+
+/**
+ * These tests are validated primarily at COMPILE time: the `@ts-expect-error`
+ * lines fail the build if the key-space stops being enforced, and the `Equal<>`
+ * assertions fail if `DeepKeys` derives the wrong union. The jasmine assertions
+ * only confirm the typed keys still resolve at runtime.
+ */
+describe("Typed translation keys", () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideTestableTranslateService({ loader: provideTranslateLoader(FakeLoader) }),
+                { provide: TranslatePipe, useClass: TranslatePipe },
+            ],
+        });
+    });
+
+    describe("TranslateService<Key> — per-instance generic", () => {
+        it("accepts in-union keys and rejects out-of-union keys", () => {
+            const translate = TestBed.inject<TranslateService<MyKeys>>(TranslateService<MyKeys>);
+            translate.use("en");
+            translate.setTranslation("en", translations, true);
+
+            // In-union keys: every key-accepting method compiles.
+            translate.instant("a");
+            translate.get("b.a");
+            translate.stream("b.b");
+            translate.getStreamOnTranslationChange("c");
+            translate.translate("a");
+            translate.translate(["a", "c"]);
+            translate.getParsedResult("b.a");
+            translate.set("a", "A");
+
+            // @ts-expect-error - "c.c" is not a declared key
+            translate.get("c.c");
+            // @ts-expect-error - "b" is an intermediate object, not a leaf key
+            translate.instant("b");
+            // @ts-expect-error - arrays are key-checked element-wise
+            translate.get(["a", "nope"]);
+            // @ts-expect-error - set() is key-checked too
+            translate.set("nope", "X");
+            // @ts-expect-error - stream() is key-checked
+            translate.stream("nope");
+            // @ts-expect-error - getStreamOnTranslationChange() is key-checked
+            translate.getStreamOnTranslationChange("b");
+            // @ts-expect-error - translate() is key-checked
+            translate.translate("nope");
+            // @ts-expect-error - translate() arrays are key-checked element-wise
+            translate.translate(["a", "nope"]);
+            // @ts-expect-error - getParsedResult() is key-checked
+            translate.getParsedResult("c.c");
+
+            expect(translate.instant("a")).toBe("A");
+        });
+
+        it("keeps the parent/root chain typed to the same key-space", () => {
+            const translate = TestBed.inject<TranslateService<MyKeys>>(TranslateService<MyKeys>);
+            const root: TranslateService<MyKeys> = translate.getRoot();
+            const parent: TranslateService<MyKeys> | null = translate.getParent();
+
+            expect(root).toBe(translate);
+            expect(parent).toBeNull();
+        });
+    });
+
+    describe("TranslatePipe<Key> — per-instance generic", () => {
+        it("accepts in-union keys and rejects out-of-union keys", () => {
+            const translate = TestBed.inject<TranslateService<MyKeys>>(TranslateService<MyKeys>);
+            const pipe = TestBed.inject<TranslatePipe<MyKeys>>(TranslatePipe<MyKeys>);
+            translate.use("en");
+            translate.setTranslation("en", translations, true);
+
+            pipe.transform("a");
+            pipe.transform("b.a");
+
+            // @ts-expect-error - "c.c" is not a declared key
+            pipe.transform("c.c");
+            // @ts-expect-error - "b" is an intermediate object, not a leaf key
+            pipe.transform("b");
+
+            expect(pipe.transform("b.a")).toBe("BA");
+        });
+    });
+
+    describe("Backward compatibility — default key type is string", () => {
+        it("accepts arbitrary string keys when no generic is supplied", () => {
+            const translate = TestBed.inject(TranslateService);
+            translate.use("en");
+            translate.setTranslation("en", translations, true);
+
+            // Any string is allowed, so existing apps keep compiling unchanged.
+            translate.instant("any.key.at.all");
+            translate.get(["whatever", "you.like"]);
+            translate.set("dynamic", "value");
+
+            expect(translate.instant("a")).toBe("A");
+        });
+    });
+
+    describe("DeepKeys — dotted leaf paths from a translation shape", () => {
+        interface Sample {
+            a: "A";
+            b: { a: "BA"; b: "BB" };
+            c: "C";
+        }
+
+        it("derives the leaf-path union", () => {
+            const isLeafUnion: Equal<DeepKeys<Sample>, MyKeys> = true;
+            expect(isLeafUnion).toBe(true);
+        });
+
+        it("excludes intermediate object paths", () => {
+            const leaf: DeepKeys<Sample> = "b.a";
+            // @ts-expect-error - "b" is an intermediate object, not a leaf path
+            const intermediate: DeepKeys<Sample> = "b";
+
+            expect(leaf).toBe("b.a");
+            expect(intermediate).toBe("b");
+        });
+
+        it("treats array and non-string-primitive values as leaf keys", () => {
+            // ngx-translate supports array translation values; they are
+            // translated under their own key, not indexed into. Primitives
+            // (number/boolean) and optional members must also survive as leaves.
+            interface WithArrayAndPrimitives {
+                bullets: string[];
+                count: number;
+                home: { title: "Home" };
+                maybe?: string;
+            }
+            type Expected = "bullets" | "count" | "home.title" | "maybe";
+
+            const isLeafUnion: Equal<DeepKeys<WithArrayAndPrimitives>, Expected> = true;
+            const arrayKey: DeepKeys<WithArrayAndPrimitives> = "bullets";
+            // @ts-expect-error - "bullets.0" is not a key: arrays are leaves, not indexed
+            const indexed: DeepKeys<WithArrayAndPrimitives> = "bullets.0";
+
+            expect(isLeafUnion).toBe(true);
+            expect(arrayKey).toBe("bullets");
+            expect(indexed).toBe("bullets.0");
+        });
+    });
+});

--- a/projects/ngx-translate/template-tests/bad-block.component.ts
+++ b/projects/ngx-translate/template-tests/bad-block.component.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+import { TranslateBlockDirective } from "@ngx-translate/core";
+import "./registry";
+
+/**
+ * Negative proof for the `*translateBlock` `t()` helper: an out-of-union key
+ * must be rejected by `strictTemplates`. The runner expects this program to
+ * FAIL to compile, citing `does.not.exist`. This is the surface the type-level
+ * test can only assert by contract; here it is checked by a real ngtsc compile.
+ */
+@Component({
+    selector: "app-bad-block",
+    standalone: true,
+    imports: [TranslateBlockDirective],
+    template: `<ng-container *translateBlock="let t">{{ t("does.not.exist") }}</ng-container>`,
+})
+export class BadBlockComponent {}

--- a/projects/ngx-translate/template-tests/bad-directive.component.ts
+++ b/projects/ngx-translate/template-tests/bad-directive.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import { TranslateDirective } from "@ngx-translate/core";
+import "./registry";
+
+/**
+ * Negative proof for the `[translate]` directive: an out-of-union key must be
+ * rejected by `strictTemplates`. The runner expects this program to FAIL to
+ * compile, citing `does.not.exist`.
+ */
+@Component({
+    selector: "app-bad-directive",
+    standalone: true,
+    imports: [TranslateDirective],
+    template: `<p [translate]="'does.not.exist'"></p>`,
+})
+export class BadDirectiveComponent {}

--- a/projects/ngx-translate/template-tests/bad-pipe.component.ts
+++ b/projects/ngx-translate/template-tests/bad-pipe.component.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+import { TranslatePipe } from "@ngx-translate/core";
+import "./registry";
+
+/**
+ * Negative proof for the `| translate` pipe: an out-of-union key must be
+ * rejected by `strictTemplates`. The runner expects this program to FAIL to
+ * compile, citing `does.not.exist`. If it compiles, pipe key enforcement
+ * regressed in templates.
+ */
+@Component({
+    selector: "app-bad-pipe",
+    standalone: true,
+    imports: [TranslatePipe],
+    template: `{{ "does.not.exist" | translate }}`,
+})
+export class BadPipeComponent {}

--- a/projects/ngx-translate/template-tests/good.component.ts
+++ b/projects/ngx-translate/template-tests/good.component.ts
@@ -1,0 +1,22 @@
+import { Component } from "@angular/core";
+import { TranslateBlockDirective, TranslateDirective, TranslatePipe } from "@ngx-translate/core";
+import "./registry";
+
+/**
+ * Positive end-to-end proof: with the registry augmented, in-union keys compile
+ * clean under `strictTemplates` across all three template surfaces — the
+ * `| translate` pipe, the `[translate]` directive, and the `*translateBlock`
+ * `t()` helper. If template typing regressed (lost) or over-narrowed
+ * (rejected a valid key), this component would fail to compile.
+ */
+@Component({
+    selector: "app-good-keys",
+    standalone: true,
+    imports: [TranslatePipe, TranslateDirective, TranslateBlockDirective],
+    template: `
+        <p>{{ "home.title" | translate }}</p>
+        <p [translate]="'nav.back'"></p>
+        <ng-container *translateBlock="let t">{{ t("home.subtitle") }}</ng-container>
+    `,
+})
+export class GoodKeysComponent {}

--- a/projects/ngx-translate/template-tests/registry.ts
+++ b/projects/ngx-translate/template-tests/registry.ts
@@ -1,0 +1,20 @@
+/**
+ * Registry augmentation shared by every template-test program.
+ *
+ * `declare module` augmentation is compilation-global, so these template tests
+ * live in their own isolated `ngc` programs (see the `tsconfig.*.json` files in
+ * this folder, run via `pnpm run test-templates`) — augmenting the registry in
+ * the karma spec or the app would retype every other template.
+ */
+import { DeepKeys } from "@ngx-translate/core";
+
+interface EnTranslations {
+    home: { title: "Home"; subtitle: "Welcome" };
+    nav: { back: "Back" };
+}
+
+declare module "@ngx-translate/core" {
+    interface NgxTranslateConfig {
+        keys: DeepKeys<EnTranslations>;
+    }
+}

--- a/projects/ngx-translate/template-tests/run.mjs
+++ b/projects/ngx-translate/template-tests/run.mjs
@@ -1,0 +1,67 @@
+/**
+ * End-to-end template type-check harness for the typed-key feature.
+ *
+ * Plain `tsc` (the `type-tests/` program) can assert the *type contract* a
+ * template surface exposes, but only the Angular template compiler (ngtsc)
+ * actually checks the string literal inside `{{ 'key' | translate }}`,
+ * `[translate]="'key'"`, and `{{ t('key') }}`. This runner drives ngtsc once
+ * per isolated program and asserts:
+ *
+ *   - good: in-union keys compile clean (exit 0),
+ *   - bad-*: an out-of-union key is REJECTED (non-zero exit, citing the key).
+ *
+ * Run via `pnpm run test-templates`.
+ */
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ngc = join(here, "..", "..", "..", "node_modules", ".bin", "ngc");
+const OUT_OF_UNION_KEY = "does.not.exist";
+
+function compile(config) {
+    try {
+        execFileSync(ngc, ["-p", join(here, config)], { stdio: "pipe", encoding: "utf8" });
+        return { ok: true, out: "" };
+    } catch (error) {
+        return { ok: false, out: `${error.stdout ?? ""}${error.stderr ?? ""}` };
+    }
+}
+
+let failures = 0;
+
+const good = compile("tsconfig.good.json");
+if (good.ok) {
+    console.log("PASS  in-union keys compile across pipe, [translate], *translateBlock");
+} else {
+    failures++;
+    console.log(`FAIL  in-union keys should compile but ngtsc errored:\n${good.out}`);
+}
+
+const negatives = [
+    ["tsconfig.bad-pipe.json", "| translate pipe"],
+    ["tsconfig.bad-directive.json", "[translate] directive"],
+    ["tsconfig.bad-block.json", "*translateBlock t()"],
+];
+
+for (const [config, label] of negatives) {
+    const result = compile(config);
+    if (!result.ok && result.out.includes(OUT_OF_UNION_KEY)) {
+        console.log(`PASS  ${label} rejects an out-of-union key`);
+    } else if (!result.ok) {
+        failures++;
+        console.log(`FAIL  ${label} errored, but not on the expected key:\n${result.out}`);
+    } else {
+        failures++;
+        console.log(
+            `FAIL  ${label} accepted an out-of-union key — template enforcement is missing`,
+        );
+    }
+}
+
+if (failures > 0) {
+    console.error(`\n${failures} template type-check assertion(s) failed.`);
+    process.exit(1);
+}
+console.log("\nAll template type-check assertions passed.");

--- a/projects/ngx-translate/template-tests/tsconfig.bad-block.json
+++ b/projects/ngx-translate/template-tests/tsconfig.bad-block.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.base.json",
+    "files": ["registry.ts", "bad-block.component.ts"]
+}

--- a/projects/ngx-translate/template-tests/tsconfig.bad-directive.json
+++ b/projects/ngx-translate/template-tests/tsconfig.bad-directive.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.base.json",
+    "files": ["registry.ts", "bad-directive.component.ts"]
+}

--- a/projects/ngx-translate/template-tests/tsconfig.bad-pipe.json
+++ b/projects/ngx-translate/template-tests/tsconfig.bad-pipe.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.base.json",
+    "files": ["registry.ts", "bad-pipe.component.ts"]
+}

--- a/projects/ngx-translate/template-tests/tsconfig.base.json
+++ b/projects/ngx-translate/template-tests/tsconfig.base.json
@@ -1,0 +1,20 @@
+/* Base config for the isolated ngtsc template-test programs. Each leaf config
+   includes `registry.ts` (the global augmentation) plus exactly one component,
+   so the augmentation never leaks into the karma spec or the app. Resolves
+   `@ngx-translate/core` to the library source so the tests run against the
+   current, unbuilt code. Run via `pnpm run test-templates`. */
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [],
+        "paths": {
+            "@ngx-translate/core": ["../src/public-api"]
+        },
+        "resolveJsonModule": true
+    },
+    "angularCompilerOptions": {
+        "strictTemplates": true
+    }
+}

--- a/projects/ngx-translate/template-tests/tsconfig.good.json
+++ b/projects/ngx-translate/template-tests/tsconfig.good.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.base.json",
+    "files": ["registry.ts", "good.component.ts"]
+}

--- a/projects/ngx-translate/type-tests/registry-augmentation.type-test.ts
+++ b/projects/ngx-translate/type-tests/registry-augmentation.type-test.ts
@@ -1,0 +1,156 @@
+/**
+ * Isolated type-test — NOT part of the karma spec suite.
+ *
+ * `NgxTranslateConfig` augmentation is compilation-global: doing it inside the
+ * shared spec program would retype every other spec that uses arbitrary string
+ * keys. So the global-default path is proven here, in its own `tsc` program
+ * (see `tsconfig.json` in this folder, run via `pnpm run test-types`).
+ *
+ * This proves the half the per-instance generic can't: that augmenting the
+ * registry retypes the DEFAULT service, pipe and directive — the ones Angular
+ * resolves in templates, where no type argument can be passed.
+ */
+import {
+    DeepKeys,
+    injectTranslateService,
+    translate,
+    TranslateBlockContext,
+    TranslateDirective,
+    TranslatePipe,
+    TranslateService,
+    TranslationKey,
+} from "@ngx-translate/core";
+import { inject } from "@angular/core";
+
+// Stands in for `typeof en` where `en` is a statically-imported translation
+// JSON (the documented usage); a literal type exercises DeepKeys identically.
+interface EnTranslations {
+    home: { title: "Home"; subtitle: "Welcome" };
+    nav: { back: "Back" };
+}
+
+type AppKeys = "home.title" | "home.subtitle" | "nav.back";
+
+declare module "@ngx-translate/core" {
+    interface NgxTranslateConfig {
+        keys: DeepKeys<EnTranslations>;
+    }
+}
+
+type Equal<A, B> =
+    (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// 1. Augmenting the registry (with a DeepKeys-derived union) resolves the
+//    library-wide default key type to that union.
+type _ResolvedKey = Expect<Equal<TranslationKey, AppKeys>>;
+
+// 2. The default service — `inject(TranslateService)`, no generic — is keyed to
+//    the union on every key-accepting method.
+type _DefaultServiceKey = Expect<
+    Equal<Parameters<TranslateService["instant"]>[0], AppKeys | AppKeys[]>
+>;
+
+// 3. The template-facing pipe signature: exactly what `strictTemplates` checks
+//    for `{{ key | translate }}`.
+type _PipeArg = Expect<
+    Equal<Parameters<TranslatePipe["transform"]>[0], AppKeys | undefined | null>
+>;
+
+// 4. The template-facing directive input: exactly what `strictTemplates` checks
+//    for `[translate]="key"`.
+type _DirectiveInput = Expect<Equal<TranslateDirective["translate"], AppKeys>>;
+
+// 4b. The `*translateBlock` template helper: the `t` bound via `let t` gets its
+//     type from `TranslateBlockContext.$implicit` (read by the directive's
+//     ngTemplateContextGuard), so this is exactly the key type `strictTemplates`
+//     checks for `{{ t('key') }}`. (A full ngtsc template compile isn't
+//     available in this plain-tsc harness — same limitation as the directive
+//     check above; this asserts the same context-type contract ngtsc reads.)
+type _BlockHelperKey = Expect<Equal<Parameters<TranslateBlockContext["$implicit"]>[0], AppKeys>>;
+
+// 5. `injectTranslateService()` resolves to the augmented union with no type
+//    argument and no annotation — the zero-ceremony imperative path. (A bare
+//    `inject(TranslateService)` widens the key to `any`, which is why the helper
+//    exists; the annotated form below is the other supported pattern.) Call-site
+//    inference is proven functionally below — a `ReturnType<>` probe would read
+//    the constraint, not the default, so it is not a faithful test here.
+function checkImperativeInjectionEnforcesKeys(): void {
+    const translate = injectTranslateService();
+    translate.instant("home.title");
+    translate.get("nav.back");
+
+    // @ts-expect-error - "home" is an intermediate object, not a leaf key
+    translate.instant("home");
+    // @ts-expect-error - not a declared key
+    translate.get("does.not.exist");
+
+    // Annotating a bare inject() works too.
+    const annotated: TranslateService = inject(TranslateService);
+    // @ts-expect-error - registry keys enforced through the annotation
+    annotated.set("nope", "x");
+}
+
+// 6. The standalone `translate()` function resolves to the augmented union with
+//    no type argument. `Key` is `NoInfer`-wrapped, so it is NOT inferred from
+//    the argument (which would silently disable checking); the registry default
+//    governs. An explicit `translate<OtherKeys>(…)` override still works.
+function checkStandaloneTranslateEnforcesKeys(): void {
+    translate("home.title");
+    translate(["home.title", "nav.back"]);
+    translate(() => "nav.back");
+
+    // @ts-expect-error - not a declared key
+    translate("does.not.exist");
+    // @ts-expect-error - "home" is an intermediate object, not a leaf key
+    translate("home");
+    // @ts-expect-error - arrays are key-checked element-wise
+    translate(["home.title", "nope"]);
+}
+
+// 7. The `[translate]` directive input is key-checked at the type level — the
+//    template-facing assignment `strictTemplates` performs for `[translate]="…"`.
+function checkDirectiveInputIsKeyChecked(dir: TranslateDirective): void {
+    dir.translate = "home.title";
+    // @ts-expect-error - directive input is key-checked against the registry
+    dir.translate = "nope";
+}
+
+// 8. Big-dictionary stress: DeepKeys must resolve a deeply-nested (10 levels)
+//    and wide (100 leaves) shape without tripping TypeScript's
+//    instantiation-depth or union-size ceiling (the well-known i18next failure
+//    mode). If `DeepKeys<BigDictionary>` exceeded a ceiling, this file would
+//    fail to compile (TS2589) — so compilation IS the assertion. The explicit
+//    leaf/intermediate checks document the resolved envelope.
+type WideDigit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type WideKey = `k${WideDigit}${WideDigit}`; // 100 distinct leaf keys
+interface BigDictionary {
+    deep: { a: { b: { c: { d: { e: { f: { g: { h: { i: { leaf: "x" } } } } } } } } } };
+    wide: Record<WideKey, string>;
+    home: { title: "Home" };
+}
+function checkBigDictionaryStaysTyped(key: DeepKeys<BigDictionary>): void {
+    const deepLeaf: DeepKeys<BigDictionary> = "deep.a.b.c.d.e.f.g.h.i.leaf";
+    const wideLeaf: DeepKeys<BigDictionary> = "wide.k00";
+    // @ts-expect-error - "deep" is an intermediate object, not a leaf
+    const intermediate: DeepKeys<BigDictionary> = "deep";
+    void key;
+    void deepLeaf;
+    void wideLeaf;
+    void intermediate;
+}
+
+// Reference the checks so unused-symbol settings stay satisfied either way.
+export type RegistryAugmentationChecks = [
+    _ResolvedKey,
+    _DefaultServiceKey,
+    _PipeArg,
+    _DirectiveInput,
+    _BlockHelperKey,
+];
+export {
+    checkImperativeInjectionEnforcesKeys,
+    checkStandaloneTranslateEnforcesKeys,
+    checkDirectiveInputIsKeyChecked,
+    checkBigDictionaryStaysTyped,
+};

--- a/projects/ngx-translate/type-tests/tsconfig.json
+++ b/projects/ngx-translate/type-tests/tsconfig.json
@@ -1,0 +1,17 @@
+/* Isolated program for registry-augmentation type-tests. Kept separate from the
+   spec suite because `declare module` augmentation is compilation-global. Run
+   with `pnpm run test-types`. Resolves `@ngx-translate/core` to the library
+   source so the test runs against the current, unbuilt code. */
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [],
+        "paths": {
+            "@ngx-translate/core": ["../src/public-api"]
+        },
+        "resolveJsonModule": true
+    },
+    "include": ["./**/*.type-test.ts"]
+}


### PR DESCRIPTION
## Typed translation keys — augmentable registry + `DeepKeys`

Opt-in compile-time validation and autocomplete for translation keys across the **whole** public surface — both the imperative API and the template APIs. Fully backward-compatible: with no augmentation, every key type stays `string` and existing apps compile unchanged.

Supersedes the per-instance-generic approach in #1620 (keeps that as an escape hatch) by making the registry the default key source, so plain `inject(TranslateService)`, `{{ key | translate }}`, `[translate]`, and `*translateBlock` are all keyed without per-call-site ceremony.

### How you opt in

```ts
import en from "./assets/i18n/en.json";

declare module "@ngx-translate/core" {
  interface NgxTranslateConfig {
    keys: DeepKeys<typeof en>;
  }
}
```

That one augmentation retypes the entire library to the app's key-space — code and templates.

### What's added

- **`NgxTranslateConfig`** — augmentable registry interface (i18next `CustomTypeOptions` pattern). Ships empty, so `TranslationKey` falls back to `string`.
- **`TranslationKey`** — resolves to the augmented `keys` union, or `string` when unaugmented.
- **`DeepKeys<T>`** — derives the dotted leaf-path union from a translation shape (`{ a: "A", b: { c: "C" } }` → `"a" | "b.c"`). Arrays and primitives are leaf keys; only plain objects recurse.
- **`injectTranslateService<Key>()`** — keyed inject helper (a bare `inject(TranslateService)` of a generic class widens the key to `any`).
- Generic threading on `TranslateService<Key>`, `TranslatePipe<Key>`, the `[translate]` directive, the `*translateBlock` `t()` helper, and the standalone `translate()` function.

### Key-space coverage

| Surface | Registry default (code + template) | Per-instance `<Key>` override |
|---|---|---|
| `TranslateService` | ✅ | ✅ `inject<TranslateService<K>>(…)` |
| `translate()` fn | ✅ | ✅ `translate<K>(…)` |
| `TranslatePipe` | ✅ | ✅ (imperative only; templates can't pass type args) |
| `[translate]` directive | ✅ | — (not generic; templates can't pass type args) |
| `*translateBlock` `t()` | ✅ | — (not generic) |

### Known limitation

The design assumes a **single global key-space**. Per-subtree / per-child-service typed key-spaces are not supported: templates can't pass type arguments, and the parent/root chain carries `Key` cosmetically (TS method bivariance), so a mixed-key-space hierarchy isn't soundly typed. Per-instance `<Key>` overrides remain a code-only escape hatch.

### Tests

- **Type-level** (`type-tests/`, `pnpm run test-types`): registry augmentation retypes the default service/pipe/directive/block/`translate()`; positive + `@ts-expect-error` negative coverage; a big-dictionary stress fixture (10-level deep, 100-leaf wide) guarding the `tsc` recursion / union-size ceiling.
- **End-to-end template** (`template-tests/`, `pnpm run test-templates`): real `ngtsc` `strictTemplates` compiles proving in-union keys compile and out-of-union keys are **rejected** on all three template surfaces (`| translate`, `[translate]`, `*translateBlock`).
- **Runtime** (`translate.type-safety.spec.ts`): per-instance generic on service + pipe, backward-compat default-`string` path, `DeepKeys` leaf derivation incl. arrays.
- CI now runs `test-types` and `test-templates` in the `build` job.

### Compatibility

No runtime behavior change — all changes are type-level (erased at compile time). `ng test`: 432 (ngx-translate) + 28 (http-loader) pass; `build-all`, `lint`, `test-types`, `test-templates` all green.
