### PR TITLE
feat(core): add interpolation context to translate parser

### DIFF
--- a/projects/ngx-translate/src/lib/translate.parser.ts
+++ b/projects/ngx-translate/src/lib/translate.parser.ts
@@ -1,8 +1,19 @@
 import { Injectable } from "@angular/core";
 import { getValue, isArray, isFunction, isObject, isString } from "./util";
-import { InterpolationParameters } from "./translate.service.interface";
+import type { InterpolationParameters } from "./translate.service.interface";
 
-export type InterpolateFunction = (params?: InterpolationParameters) => string;
+export interface InterpolationContext {
+    /** The translation key requested from TranslateService. */
+    key?: string;
+
+    /** The language that supplied the translation being interpolated. */
+    lang?: string;
+}
+
+export type InterpolateFunction = (
+    params?: InterpolationParameters,
+    context?: InterpolationContext,
+) => string;
 
 export abstract class TranslateParser {
     /**
@@ -14,6 +25,7 @@ export abstract class TranslateParser {
     abstract interpolate(
         expr: InterpolateFunction | string,
         params?: InterpolationParameters,
+        context?: InterpolationContext,
     ): string | undefined;
 }
 
@@ -24,11 +36,12 @@ export class TranslateDefaultParser extends TranslateParser {
     public interpolate(
         expr: InterpolateFunction | string,
         params?: InterpolationParameters,
+        context?: InterpolationContext,
     ): string | undefined {
         if (isString(expr)) {
-            return this.interpolateString(expr as string, params);
+            return this.interpolateString(expr as string, params, context);
         } else if (isFunction(expr)) {
-            return this.interpolateFunction(expr as InterpolateFunction, params);
+            return this.interpolateFunction(expr as InterpolateFunction, params, context);
         }
         return undefined;
     }
@@ -36,17 +49,22 @@ export class TranslateDefaultParser extends TranslateParser {
     protected interpolateFunction(
         fn: InterpolateFunction,
         params?: InterpolationParameters,
+        context?: InterpolationContext,
     ): string {
-        return fn(params);
+        return fn(params, context);
     }
 
-    protected interpolateString(expr: string, params?: InterpolationParameters): string {
+    protected interpolateString(
+        expr: string,
+        params?: InterpolationParameters,
+        context?: InterpolationContext,
+    ): string {
         if (!params) {
             return expr;
         }
 
         return expr.replace(this.templateMatcher, (substring: string, key: string) => {
-            const replacement = this.getInterpolationReplacement(params, key);
+            const replacement = this.getInterpolationReplacement(params, key, context);
             return replacement !== undefined ? replacement : substring;
         });
     }
@@ -58,8 +76,9 @@ export class TranslateDefaultParser extends TranslateParser {
     protected getInterpolationReplacement(
         params: InterpolationParameters,
         key: string,
+        context?: InterpolationContext,
     ): string | undefined {
-        return this.formatValue(getValue(params, key));
+        return this.formatValue(getValue(params, key), context);
     }
 
     /**
@@ -67,7 +86,8 @@ export class TranslateDefaultParser extends TranslateParser {
      * @param value The value to format.
      * @returns A string representation of the value.
      */
-    protected formatValue(value: unknown): string | undefined {
+    protected formatValue(value: unknown, context?: InterpolationContext): string | undefined {
+        void context;
         if (isString(value)) {
             return value;
         }

--- a/projects/ngx-translate/src/lib/translate.service.ts
+++ b/projects/ngx-translate/src/lib/translate.service.ts
@@ -28,7 +28,7 @@ import { LoadingTranslationsRegistry } from "./loading-translations-registry";
 import { MissingTranslationHandler } from "./missing-translation-handler";
 import { TranslateCompiler } from "./translate.compiler";
 import { TranslateLoader } from "./translate.loader";
-import { TranslateParser } from "./translate.parser";
+import { TranslateParser, type InterpolationContext } from "./translate.parser";
 import { DeepReadonly, TranslateStore } from "./translate.store";
 import { insertValue, isArray, isDefinedAndNotNull, isDict, isString } from "./util";
 import {
@@ -75,6 +75,11 @@ declare const window: Window;
 const makeObservable = <T>(value: T | Observable<T>): Observable<T> => {
     return isObservable(value) ? value : of(value);
 };
+
+interface TranslationLookupResult {
+    translation: InterpolatableTranslation;
+    context: InterpolationContext;
+}
 
 @Injectable()
 export class TranslateService implements ITranslateService {
@@ -612,10 +617,10 @@ export class TranslateService implements ITranslateService {
         interpolateParams?: InterpolationParameters,
         lang?: Language,
     ): StrictTranslation | Observable<StrictTranslation> {
-        const textToInterpolate = this.getTextToInterpolate(key, lang);
+        const lookup = this.getTextToInterpolateWithContext(key, lang);
 
-        if (isDefinedAndNotNull(textToInterpolate)) {
-            return this.runInterpolation(textToInterpolate, interpolateParams);
+        if (lookup && isDefinedAndNotNull(lookup.translation)) {
+            return this.runInterpolation(lookup.translation, interpolateParams, lookup.context);
         }
 
         const handler = this.getMissingTranslationHandler();
@@ -643,12 +648,19 @@ export class TranslateService implements ITranslateService {
         key: string,
         lang?: Language,
     ): InterpolatableTranslation | undefined {
+        return this.getTextToInterpolateWithContext(key, lang)?.translation;
+    }
+
+    protected getTextToInterpolateWithContext(
+        key: string,
+        lang?: Language,
+    ): TranslationLookupResult | undefined {
         if (lang) {
             const res = this.store.getTranslationValue(lang, key);
             if (res !== undefined) {
-                return res;
+                return { translation: res, context: { key, lang } };
             }
-            return this.parent?.getTextToInterpolate(key, lang);
+            return this.parent?.getTextToInterpolateWithContext(key, lang);
         }
 
         const currentLang = this.getCurrentLang();
@@ -656,58 +668,67 @@ export class TranslateService implements ITranslateService {
 
         // 1. Try own store (currentLang)
         let res: InterpolatableTranslation | undefined;
+        let resLang: Language | undefined;
         if (currentLang) {
             res = this.store.getTranslationValue(currentLang, key);
+            resLang = currentLang;
         }
 
         // 2. Try own store (fallbackLang) - null values also trigger fallback
         if (!isDefinedAndNotNull(res) && fallbackLang && fallbackLang !== currentLang) {
             res = this.store.getTranslationValue(fallbackLang, key);
+            resLang = fallbackLang;
         }
 
         if (res !== undefined) {
-            return res;
+            return {
+                translation: res,
+                context: resLang === undefined ? { key } : { key, lang: resLang },
+            };
         }
 
         // 3. Try parent
-        return this.parent?.getTextToInterpolate(key);
+        return this.parent?.getTextToInterpolateWithContext(key);
     }
 
     protected runInterpolation(
         translations: InterpolatableTranslation,
         interpolateParams?: InterpolationParameters,
+        context?: InterpolationContext,
     ): StrictTranslation {
         if (!isDefinedAndNotNull(translations)) {
             return;
         }
 
         if (isArray(translations)) {
-            return this.runInterpolationOnArray(translations, interpolateParams);
+            return this.runInterpolationOnArray(translations, interpolateParams, context);
         }
 
         if (isDict(translations)) {
-            return this.runInterpolationOnDict(translations, interpolateParams);
+            return this.runInterpolationOnDict(translations, interpolateParams, context);
         }
 
-        return this.parser.interpolate(translations, interpolateParams);
+        return this.parser.interpolate(translations, interpolateParams, context);
     }
 
     protected runInterpolationOnArray(
         translations: InterpolatableTranslation,
         interpolateParams: InterpolationParameters | undefined,
+        context?: InterpolationContext,
     ) {
         return (translations as StrictTranslation[]).map((translation) =>
-            this.runInterpolation(translation, interpolateParams),
+            this.runInterpolation(translation, interpolateParams, context),
         );
     }
 
     protected runInterpolationOnDict(
         translations: InterpolatableTranslationObject,
         interpolateParams: InterpolationParameters | undefined,
+        context?: InterpolationContext,
     ) {
         const result: TranslationObject = {};
         for (const key in translations) {
-            const res = this.runInterpolation(translations[key], interpolateParams);
+            const res = this.runInterpolation(translations[key], interpolateParams, context);
             if (res !== undefined) {
                 result[key] = res;
             }

--- a/projects/ngx-translate/src/tests/translate.parser.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.parser.spec.ts
@@ -1,6 +1,7 @@
 import {
     getValue,
     InterpolateFunction,
+    InterpolationContext,
     TranslateDefaultParser,
     TranslateParser,
 } from "../public-api";
@@ -55,6 +56,36 @@ describe("Parser", () => {
             };
 
             expect(parser.interpolate(uc, { x: "bless" })).toEqual("BLESS YOU!");
+        });
+
+        it("should pass context to interpolation functions", () => {
+            const interpolationContext: InterpolationContext = { key: "TEST", lang: "en" };
+            const fn: InterpolateFunction = (params, context) => {
+                return `${context?.key}:${context?.lang}:${getValue(params, "x")}`;
+            };
+
+            expect(parser.interpolate(fn, { x: "value" }, interpolationContext)).toEqual(
+                "TEST:en:value",
+            );
+        });
+
+        it("should pass context to protected formatting hooks", () => {
+            class ContextParser extends TranslateDefaultParser {
+                protected override formatValue(
+                    value: unknown,
+                    context?: InterpolationContext,
+                ): string | undefined {
+                    return `${context?.key}:${super.formatValue(value, context)}`;
+                }
+            }
+
+            expect(
+                new ContextParser().interpolate(
+                    "This is {{ value }}",
+                    { value: "contextual" },
+                    { key: "TEST", lang: "en" },
+                ),
+            ).toEqual("This is TEST:contextual");
         });
 
         it("should handle edge cases: value not found", () => {

--- a/projects/ngx-translate/src/tests/translate.service.spec.ts
+++ b/projects/ngx-translate/src/tests/translate.service.spec.ts
@@ -1,17 +1,22 @@
-import { Component, inject, signal, computed } from "@angular/core";
+import { Component, Injectable, Injector, computed, inject, signal } from "@angular/core";
 import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { defer, EMPTY, Observable, of, throwError, timer, zip } from "rxjs";
 import { first, map, take, toArray } from "rxjs/operators";
 import {
     InterpolatableTranslationObject,
     InterpolationParameters,
+    InterpolationContext,
+    InterpolateFunction,
     LangChangeEvent,
     provideChildTranslateService,
     provideTranslateCompiler,
     provideTranslateLoader,
+    provideTranslateParser,
     provideTranslateService,
     TranslateCompiler,
+    TranslateDefaultParser,
     TranslateLoader,
+    TranslateParser,
     TranslatePipe,
     TranslateService,
     Translation,
@@ -195,6 +200,107 @@ describe("TranslateService get() during in-flight loading", () => {
         // Now the "en" load completed → get() resolves
         expect(result).toEqual("Hello");
     }));
+});
+
+describe("TranslateService interpolation context", () => {
+    let translate: TranslateService;
+    let parser: ContextCapturingParser;
+
+    @Injectable()
+    class ContextCapturingParser extends TranslateDefaultParser {
+        readonly contexts: Array<InterpolationContext | undefined> = [];
+
+        public override interpolate(
+            expr: InterpolateFunction | string,
+            params?: InterpolationParameters,
+            context?: InterpolationContext,
+        ): string | undefined {
+            this.contexts.push(context);
+            return super.interpolate(expr, params, context);
+        }
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideTranslateService({
+                    parser: provideTranslateParser(ContextCapturingParser),
+                }),
+            ],
+        });
+        translate = TestBed.inject(TranslateService);
+        parser = TestBed.inject(TranslateParser) as ContextCapturingParser;
+    });
+
+    it("passes the current language and key to the parser", () => {
+        translate.setTranslation("de", { TEST: "Hallo {{ name }}" });
+        translate.use("de");
+
+        expect(translate.instant("TEST", { name: "Ada" })).toEqual("Hallo Ada");
+        expect(parser.contexts.at(-1)).toEqual({ key: "TEST", lang: "de" });
+    });
+
+    it("passes the fallback language when fallback supplied the translation", () => {
+        translate.setTranslation("de", {});
+        translate.setTranslation("en", { TEST: "Hello {{ name }}" });
+        translate.setFallbackLang("en");
+        translate.use("de");
+
+        expect(translate.instant("TEST", { name: "Ada" })).toEqual("Hello Ada");
+        expect(parser.contexts.at(-1)).toEqual({ key: "TEST", lang: "en" });
+    });
+});
+
+describe("TranslateService nested interpolation via parser context", () => {
+    class TranslatedParam {
+        constructor(public readonly key: string) {}
+    }
+
+    @Injectable()
+    class NestedTranslateParser extends TranslateDefaultParser {
+        private readonly injector = inject(Injector);
+
+        protected override formatValue(
+            value: unknown,
+            context?: InterpolationContext,
+        ): string | undefined {
+            if (value instanceof TranslatedParam) {
+                const translate = this.injector.get(TranslateService);
+                return super.formatValue(
+                    translate.instant(value.key, undefined, context?.lang),
+                    context,
+                );
+            }
+
+            return super.formatValue(value, context);
+        }
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideTranslateService({
+                    parser: provideTranslateParser(NestedTranslateParser),
+                }),
+            ],
+        });
+    });
+
+    it("uses the resolved outer translation language for nested translations", () => {
+        const translate = TestBed.inject(TranslateService);
+
+        translate.setTranslation("de", { INNER: "deutscher innerer Wert" });
+        translate.setTranslation("en", {
+            OUTER: "Outer {{ nested }}",
+            INNER: "English inner value",
+        });
+        translate.setFallbackLang("en");
+        translate.use("de");
+
+        expect(translate.instant("OUTER", { nested: new TranslatedParam("INNER") })).toEqual(
+            "Outer English inner value",
+        );
+    });
 });
 
 describe("TranslateService", () => {


### PR DESCRIPTION
## Summary

Adds interpolation context to `TranslateParser` so custom parsers can know which translation key and language are being interpolated.

## Motivation

This enables custom interpolation behaviour such as nested translations/localisations while preserving the resolved language of the outer translation, including fallback-language cases.

## Use cases

- Nested translations in interpolation params, where `{{ productName | translate }}` can resolve another translation key using the same resolved language as the outer translation.
- Localised parameter objects, where params contain `{ en: "...", de: "..." }` and the parser selects `context.lang`.
- Locale-aware number/date/currency formatting inside custom parsers.
- Debug/unit test tooling that annotates interpolated strings with the key/language that produced them.
- ICU/messageformat-style parser implementations that need the resolved language to select plural/category behavior.
- A/B or tenant-specific interpolation strategies keyed by translation namespace.

## Changes

- Added `InterpolationContext` with `key` and `lang`.
- Extended `TranslateParser.interpolate()` and default parser hooks with optional context.
- Updated `TranslateService` to pass the resolved translation key/language to the parser.
- Added coverage for parser context propagation and nested translation interpolation.
